### PR TITLE
FDSE-1111

### DIFF
--- a/pkg/polaris/graphql/graphql.go
+++ b/pkg/polaris/graphql/graphql.go
@@ -227,22 +227,26 @@ func (c *Client) Request(ctx context.Context, query string, variables interface{
 	// Remote responded without a body. For status code 200 this means we are
 	// missing the GraphQL response. For an error we have no additional details.
 	if res.ContentLength == 0 {
-		if res.StatusCode != 200 {
-			return nil, fmt.Errorf("polaris: %s", res.Status)
-		} else {
+		if res.StatusCode == 200 {
 			return nil, errors.New("polaris: no body")
 		}
-	}
-
-	// Verify that the content type of the body is JSON.
-	contentType := res.Header.Get("Content-Type")
-	if !strings.HasPrefix(contentType, "application/json") {
-		return nil, fmt.Errorf("polaris: wrong content-type: %s", contentType)
+		return nil, fmt.Errorf("polaris: %s", res.Status)
 	}
 
 	buf, err = io.ReadAll(res.Body)
 	if err != nil {
 		return nil, err
+	}
+
+	// Verify that the content type of the body is JSON. For status code 200
+	// this mean we received something that isn't a GraphQL response. For an
+	// error we have no additional JSON details.
+	contentType := res.Header.Get("Content-Type")
+	if !strings.HasPrefix(contentType, "application/json") {
+		if res.StatusCode == 200 {
+			return nil, fmt.Errorf("polaris: wrong content-type: %s", contentType)
+		}
+		return nil, fmt.Errorf("polaris: %s - %s", res.Status, string(buf))
 	}
 
 	// Remote responded with a JSON document. Try to parse it as both known

--- a/pkg/polaris/graphql/token_source_local_user.go
+++ b/pkg/polaris/graphql/token_source_local_user.go
@@ -119,8 +119,8 @@ func (src *localUserSource) token() (token, error) {
 	}
 
 	// Verify that the content type of the body is JSON. For status code 200
-	// this mean we received something that isn't a GraphQL response. For an
-	// error we have no additional JSON details.
+	// this mean we received something that isn't JSON. For an error we have no
+	// additional JSON details.
 	contentType := res.Header.Get("Content-Type")
 	if !strings.HasPrefix(contentType, "application/json") {
 		if res.StatusCode == 200 {

--- a/pkg/polaris/graphql/token_source_service_account.go
+++ b/pkg/polaris/graphql/token_source_service_account.go
@@ -83,22 +83,26 @@ func (src *serviceAccountSource) token() (token, error) {
 	// Remote responded without a body. For status code 200 this means we are
 	// missing the token. For an error we have no additional details.
 	if res.ContentLength == 0 {
-		if res.StatusCode != 200 {
-			return token{}, fmt.Errorf("polaris: %s", res.Status)
-		} else {
+		if res.StatusCode == 200 {
 			return token{}, errors.New("polaris: no body")
 		}
-	}
-
-	// Verify that the content type of the body is JSON.
-	contentType := res.Header.Get("Content-Type")
-	if !strings.HasPrefix(contentType, "application/json") {
-		return token{}, fmt.Errorf("polaris: wrong content-type: %s", contentType)
+		return token{}, fmt.Errorf("polaris: %s", res.Status)
 	}
 
 	buf, err = io.ReadAll(res.Body)
 	if err != nil {
 		return token{}, err
+	}
+
+	// Verify that the content type of the body is JSON. For status code 200
+	// this mean we received something that isn't JSON. For an error we have no
+	// additional JSON details.
+	contentType := res.Header.Get("Content-Type")
+	if !strings.HasPrefix(contentType, "application/json") {
+		if res.StatusCode == 200 {
+			return token{}, fmt.Errorf("polaris: wrong content-type: %s", contentType)
+		}
+		return token{}, fmt.Errorf("polaris: %s - %s", res.Status, string(buf))
 	}
 
 	// Remote responded with a JSON document. Try to parse it as an error


### PR DESCRIPTION
HTTP Responses with a body, content-type other than application/json and a status code other than 200 now returns a less cryptic error message.