### PR TITLE
Remove "and counting" from the Jenkins duration string

### DIFF
--- a/Jenkinsfile
+++ b/Jenkinsfile
@@ -87,7 +87,7 @@ pipeline {
                     slackSend(
                         channel: '#terraform-provider-development',
                         color: 'good',
-                        message: "The pipeline ${currentBuild.fullDisplayName} succeeded (runtime: ${currentBuild.durationString})\n${currentBuild.absoluteUrl}"
+                        message: "The pipeline ${currentBuild.fullDisplayName} succeeded (runtime: ${currentBuild.durationString.minus(' and counting')})\n${currentBuild.absoluteUrl}"
                     )
                 }
             }
@@ -98,7 +98,7 @@ pipeline {
                     slackSend(
                         channel: '#terraform-provider-development',
                         color: 'danger',
-                        message: "The pipeline ${currentBuild.fullDisplayName} failed (runtime: ${currentBuild.durationString})\n${currentBuild.absoluteUrl}"
+                        message: "The pipeline ${currentBuild.fullDisplayName} failed (runtime: ${currentBuild.durationString.minus(' and counting')})\n${currentBuild.absoluteUrl}"
                     )
                 }
             }


### PR DESCRIPTION
For some reason Jenkins `currentBuild.durationString` always end with ` and counting`.