### PR TITLE
Retry and log token requests

### DIFF
--- a/pkg/polaris/graphql/graphql.go
+++ b/pkg/polaris/graphql/graphql.go
@@ -124,7 +124,7 @@ func NewClientFromLocalUser(ctx context.Context, app, apiURL, username, password
 		client: &http.Client{
 			Transport: &tokenTransport{
 				next: http.DefaultTransport,
-				src:  newLocalUserSource(apiURL, username, password),
+				src:  newLocalUserSource(apiURL, username, password, logger),
 			},
 		},
 		log: logger,
@@ -141,7 +141,7 @@ func NewClientFromServiceAccount(ctx context.Context, app, apiURL, accessTokenUR
 		client: &http.Client{
 			Transport: &tokenTransport{
 				next: http.DefaultTransport,
-				src:  newServiceAccountSource(accessTokenURI, clientID, clientSecret),
+				src:  newServiceAccountSource(accessTokenURI, clientID, clientSecret, logger),
 			},
 		},
 		log: logger,
@@ -150,7 +150,7 @@ func NewClientFromServiceAccount(ctx context.Context, app, apiURL, accessTokenUR
 
 // NewTestClient - Intended to be used by unit tests.
 func NewTestClient(username, password string, logger log.Logger) (*Client, *TestListener) {
-	src, lis := newLocalUserTestSource(username, password)
+	src, lis := newLocalUserTestSource(username, password, logger)
 
 	client := &Client{
 		gqlURL: "http://test/api/graphql",

--- a/pkg/polaris/graphql/token_source_service_account.go
+++ b/pkg/polaris/graphql/token_source_service_account.go
@@ -21,19 +21,17 @@
 package graphql
 
 import (
-	"bytes"
-	"context"
 	"encoding/json"
 	"errors"
-	"fmt"
-	"io"
 	"net/http"
-	"strings"
+
+	"github.com/rubrikinc/rubrik-polaris-sdk-for-go/pkg/polaris/log"
 )
 
 // serviceAccountSource holds all the information needed to obtain a token
 // for a service account.
 type serviceAccountSource struct {
+	logger       log.Logger
 	client       *http.Client
 	tokenURL     string
 	clientID     string
@@ -42,8 +40,9 @@ type serviceAccountSource struct {
 
 // newServiceAccountSource returns a new token source that uses the
 // http.DefaultClient to obtain tokens.
-func newServiceAccountSource(accessTokenURL, clientID, clientSecret string) *serviceAccountSource {
+func newServiceAccountSource(accessTokenURL, clientID, clientSecret string, logger log.Logger) *serviceAccountSource {
 	return &serviceAccountSource{
+		logger:       logger,
 		client:       http.DefaultClient,
 		tokenURL:     accessTokenURL,
 		clientID:     clientID,
@@ -53,11 +52,8 @@ func newServiceAccountSource(accessTokenURL, clientID, clientSecret string) *ser
 
 // token returns a new token from the service account token source.
 func (src *serviceAccountSource) token() (token, error) {
-	ctx, cancel := context.WithTimeout(context.Background(), tokenRequestTimeout)
-	defer cancel()
-
 	// Prepare the token request body.
-	buf, err := json.Marshal(struct {
+	body, err := json.Marshal(struct {
 		GrantType    string `json:"grant_type"`
 		ClientID     string `json:"client_id"`
 		ClientSecret string `json:"client_secret"`
@@ -66,55 +62,16 @@ func (src *serviceAccountSource) token() (token, error) {
 		return token{}, err
 	}
 
-	// Request an access token from the remote token endpoint.
-	req, err := http.NewRequestWithContext(ctx, http.MethodPost, src.tokenURL, bytes.NewReader(buf))
-	if err != nil {
-		return token{}, err
-	}
-	req.Header.Add("Content-Type", "application/json; charset=UTF-8")
-	req.Header.Add("Accept", "application/json")
-	res, err := src.client.Do(req)
-	if err != nil {
-		return token{}, err
-	}
-	defer res.Body.Close()
-
-	// Remote responded without a body. For status code 200 this means we are
-	// missing the token. For an error we have no additional details.
-	if res.ContentLength == 0 {
-		if res.StatusCode == 200 {
-			return token{}, errors.New("polaris: no body")
+	var resp []byte
+	for attempt := 1; ; attempt++ {
+		src.logger.Printf(log.Debug, "acquire access token (attempt: %d)", attempt)
+		resp, err = requestToken(src.client, src.tokenURL, body)
+		if err == nil {
+			break
 		}
-		return token{}, fmt.Errorf("polaris: %s", res.Status)
-	}
-
-	buf, err = io.ReadAll(res.Body)
-	if err != nil {
-		return token{}, err
-	}
-
-	// Verify that the content type of the body is JSON. For status code 200
-	// this mean we received something that isn't JSON. For an error we have no
-	// additional JSON details.
-	contentType := res.Header.Get("Content-Type")
-	if !strings.HasPrefix(contentType, "application/json") {
-		if res.StatusCode == 200 {
-			return token{}, fmt.Errorf("polaris: wrong content-type: %s", contentType)
+		if !errors.Is(err, errTokenRequestTimeout) || attempt == tokenRequestAttempts {
+			return token{}, err
 		}
-		return token{}, fmt.Errorf("polaris: %s - %s", res.Status, string(buf))
-	}
-
-	// Remote responded with a JSON document. Try to parse it as an error
-	// message.
-	var jsonErr jsonError
-	if err := json.Unmarshal(buf, &jsonErr); err != nil {
-		return token{}, err
-	}
-	if jsonErr.isError() {
-		return token{}, jsonErr
-	}
-	if res.StatusCode != 200 {
-		return token{}, fmt.Errorf("polaris: %s", res.Status)
 	}
 
 	// Try to parse the JSON document as an access token. Verify that the
@@ -123,7 +80,7 @@ func (src *serviceAccountSource) token() (token, error) {
 		ClientID    string `json:"client_id"`
 		AccessToken string `json:"access_token"`
 	}
-	if err := json.Unmarshal(buf, &payload); err != nil {
+	if err := json.Unmarshal(resp, &payload); err != nil {
 		return token{}, err
 	}
 	if payload.ClientID != src.clientID {

--- a/pkg/polaris/graphql/token_test.go
+++ b/pkg/polaris/graphql/token_test.go
@@ -27,6 +27,8 @@ import (
 	"strings"
 	"testing"
 	"text/template"
+
+	"github.com/rubrikinc/rubrik-polaris-sdk-for-go/pkg/polaris/log"
 )
 
 func TestTokenExpired(t *testing.T) {
@@ -69,7 +71,7 @@ func TestTokenSetAsHeader(t *testing.T) {
 }
 
 func TestTokenSource(t *testing.T) {
-	src, lis := newLocalUserTestSource("john", "doe")
+	src, lis := newLocalUserTestSource("john", "doe", &log.StandardLogger{})
 
 	// Respond with 200 and a valid token as long as the correct username and
 	// password are received.
@@ -110,7 +112,7 @@ func TestTokenSourceWithBadCredentials(t *testing.T) {
 		t.Fatal(err)
 	}
 
-	src, lis := newLocalUserTestSource("john", "doe")
+	src, lis := newLocalUserTestSource("john", "doe", &log.StandardLogger{})
 
 	// Respond with status code 401 and additional details in the body.
 	srv := TestServeJSON(lis, func(w http.ResponseWriter, req *http.Request) {
@@ -131,7 +133,7 @@ func TestTokenSourceWithBadCredentials(t *testing.T) {
 }
 
 func TestTokenSourceWithInternalServerErrorNoBody(t *testing.T) {
-	src, lis := newLocalUserTestSource("john", "doe")
+	src, lis := newLocalUserTestSource("john", "doe", &log.StandardLogger{})
 
 	// Respond with status code 500 and no additional details.
 	srv := TestServe(lis, func(w http.ResponseWriter, req *http.Request) {
@@ -149,7 +151,7 @@ func TestTokenSourceWithInternalServerErrorNoBody(t *testing.T) {
 }
 
 func TestTokenSourceWithInternalServerErrorTextBody(t *testing.T) {
-	src, lis := newLocalUserTestSource("john", "doe")
+	src, lis := newLocalUserTestSource("john", "doe", &log.StandardLogger{})
 
 	// Respond with status code 500 and no additional details.
 	srv := TestServe(lis, func(w http.ResponseWriter, req *http.Request) {


### PR DESCRIPTION
The integration tests occasionally fails due to timeouts. To mitigate
the impact of transient network issues we now retry token requests that
times out. This change also adds debug logging for all token requests.