### PR TITLE
WIP: Add testenv command for CI pre/post processing

### DIFF
--- a/go.mod
+++ b/go.mod
@@ -16,8 +16,10 @@ require (
 	github.com/golang-jwt/jwt/v4 v4.0.0
 	github.com/golang/groupcache v0.0.0-20210331224755-41bb18bfe9da // indirect
 	github.com/google/uuid v1.2.0
+	github.com/kr/pretty v0.1.0
 	golang.org/x/net v0.0.0-20210415231046-e915ea6b2b7d // indirect
 	golang.org/x/oauth2 v0.0.0-20210413134643-5e61552d6c78
+	golang.org/x/sync v0.0.0-20210220032951-036812b2e83c
 	golang.org/x/sys v0.0.0-20210415045647-66c3f260301c // indirect
 	google.golang.org/api v0.44.0
 	google.golang.org/genproto v0.0.0-20210416161957-9910b6c460de // indirect

--- a/go.sum
+++ b/go.sum
@@ -195,8 +195,10 @@ github.com/jmespath/go-jmespath/internal/testify v1.5.1/go.mod h1:L3OGu8Wl2/fWfC
 github.com/jstemmer/go-junit-report v0.0.0-20190106144839-af01ea7f8024/go.mod h1:6v2b51hI/fHJwM22ozAgKL4VKDeJcHhJFhtBdhmNjmU=
 github.com/jstemmer/go-junit-report v0.9.1/go.mod h1:Brl9GWCQeLvo8nXZwPNNblvFj/XSXhF0NWZEnDohbsk=
 github.com/kisielk/gotool v1.0.0/go.mod h1:XhKaO+MFFWcvkIS/tQcRk01m1F5IRFswLeQ+oQHNcck=
+github.com/kr/pretty v0.1.0 h1:L/CwN0zerZDmRFUapSPitk6f+Q3+0za1rQkzVuMiMFI=
 github.com/kr/pretty v0.1.0/go.mod h1:dAy3ld7l9f0ibDNOQOHHMYYIIbhfbHSm3C4ZsoJORNo=
 github.com/kr/pty v1.1.1/go.mod h1:pFQYn66WHrOpPYNljwOMqo10TkYh1fy3cYio2l3bCsQ=
+github.com/kr/text v0.1.0 h1:45sCR5RtlFHMR4UwH9sdQ5TC8v0qDQCHnXt+kaKSTVE=
 github.com/kr/text v0.1.0/go.mod h1:4Jbv+DJW3UT/LiOwJeYQe1efqtUx/iVham/4vfdArNI=
 github.com/mitchellh/go-homedir v1.1.0 h1:lukF9ziXFxDFPkA1vsr5zpc1XuPDn/wFntq5mG+4E0Y=
 github.com/mitchellh/go-homedir v1.1.0/go.mod h1:SfyaCUpYCn1Vlf4IUYiD9fPX4A5wJrkLzIz1N1q0pr0=
@@ -322,6 +324,7 @@ golang.org/x/sync v0.0.0-20200317015054-43a5402ce75a/go.mod h1:RxMgew5VJxzue5/jJ
 golang.org/x/sync v0.0.0-20200625203802-6e8e738ad208/go.mod h1:RxMgew5VJxzue5/jJTE5uejpjVlOe/izrB70Jof72aM=
 golang.org/x/sync v0.0.0-20201020160332-67f06af15bc9/go.mod h1:RxMgew5VJxzue5/jJTE5uejpjVlOe/izrB70Jof72aM=
 golang.org/x/sync v0.0.0-20201207232520-09787c993a3a/go.mod h1:RxMgew5VJxzue5/jJTE5uejpjVlOe/izrB70Jof72aM=
+golang.org/x/sync v0.0.0-20210220032951-036812b2e83c h1:5KslGYwFpkhGh+Q16bwMP3cOontH8FOep7tGV86Y7SQ=
 golang.org/x/sync v0.0.0-20210220032951-036812b2e83c/go.mod h1:RxMgew5VJxzue5/jJTE5uejpjVlOe/izrB70Jof72aM=
 golang.org/x/sys v0.0.0-20180830151530-49385e6e1522/go.mod h1:STP8DvDyc/dI5b8T5hshtkjS+E42TnysNCUPdjciGhY=
 golang.org/x/sys v0.0.0-20190215142949-d0b11bdaac8a/go.mod h1:STP8DvDyc/dI5b8T5hshtkjS+E42TnysNCUPdjciGhY=

--- a/internal/cmd/testenv/main.go
+++ b/internal/cmd/testenv/main.go
@@ -1,0 +1,186 @@
+package main
+
+import (
+	"context"
+	"errors"
+	"flag"
+	"fmt"
+	"log"
+	"os"
+
+	"github.com/kr/pretty"
+	"github.com/rubrikinc/rubrik-polaris-sdk-for-go/internal/testsetup"
+	"github.com/rubrikinc/rubrik-polaris-sdk-for-go/pkg/polaris"
+	"github.com/rubrikinc/rubrik-polaris-sdk-for-go/pkg/polaris/aws"
+	"github.com/rubrikinc/rubrik-polaris-sdk-for-go/pkg/polaris/azure"
+	"github.com/rubrikinc/rubrik-polaris-sdk-for-go/pkg/polaris/gcp"
+	"github.com/rubrikinc/rubrik-polaris-sdk-for-go/pkg/polaris/graphql"
+	"github.com/rubrikinc/rubrik-polaris-sdk-for-go/pkg/polaris/graphql/core"
+	polaris_log "github.com/rubrikinc/rubrik-polaris-sdk-for-go/pkg/polaris/log"
+	"golang.org/x/sync/errgroup"
+)
+
+func main() {
+	cleanup := flag.Bool("cleanup", false, "Perform cleanup tasks post CI")
+	precheck := flag.Bool("precheck", false, "Check pre-requirements for running CI tests")
+	flag.Parse()
+	if *cleanup == *precheck {
+		flag.Usage()
+		os.Exit(1)
+	}
+
+	ctx := context.Background()
+
+	// Load configuration and create client
+	polAccount, err := polaris.DefaultServiceAccount(true)
+	if err != nil {
+		log.Fatal(err)
+	}
+	client, err := polaris.NewClient(ctx, polAccount, &polaris_log.StandardLogger{})
+	if err != nil {
+		log.Fatal(err)
+	}
+
+	if *precheck {
+		err = check(ctx, client)
+	} else {
+		err = clean(ctx, client)
+	}
+	if err != nil {
+		log.Fatal(err)
+	}
+}
+
+func check(ctx context.Context, client *polaris.Client) error {
+	var g errgroup.Group
+
+	// AWS
+	g.Go(func() error {
+		awsAccount, err := client.AWS().Account(ctx, aws.ID(aws.Default()), core.FeatureAll)
+		switch {
+		case err == nil:
+			return fmt.Errorf("found pre-existing AWS account: %v", pretty.Sprint(awsAccount))
+		case !errors.Is(err, graphql.ErrNotFound):
+			return fmt.Errorf("failed to check AWS account: %v", err)
+		}
+		return nil
+	})
+
+	// Azure
+	g.Go(func() error {
+		testSub, err := testsetup.AzureSubscription()
+		if err != nil {
+			return err
+		}
+		azureAcc, err := client.Azure().Subscription(ctx, azure.SubscriptionID(testSub.SubscriptionID), core.FeatureAll)
+		switch {
+		case err == nil:
+			return fmt.Errorf("found pre-existing Azure subscription: %v", pretty.Sprint(azureAcc))
+		case !errors.Is(err, graphql.ErrNotFound):
+			return fmt.Errorf("failed to check Azure account: %v", err)
+		}
+		return nil
+	})
+
+	// GCP
+	g.Go(func() error {
+		testProj, err := testsetup.GCPProject()
+		if err != nil {
+			return err
+		}
+		proj, err := client.GCP().Project(ctx, gcp.ProjectID(testProj.ProjectID), core.FeatureAll)
+		switch {
+		case err == nil:
+			return fmt.Errorf("found pre-existing GCP projects: %v", pretty.Sprint(proj))
+		case !errors.Is(err, graphql.ErrNotFound):
+			return fmt.Errorf("failed to check GCP project: %v", err)
+		}
+		return nil
+	})
+
+	return g.Wait()
+}
+
+func clean(ctx context.Context, client *polaris.Client) error {
+	var g errgroup.Group
+
+	// AWS
+	g.Go(func() error {
+		awsAccount, err := client.AWS().Account(ctx, aws.ID(aws.Default()), core.FeatureAll)
+
+		switch {
+		case errors.Is(err, graphql.ErrNotFound):
+			return nil
+		case err != nil:
+			return fmt.Errorf("failed to check AWS account: %v", err)
+		}
+		testAcc, err := testsetup.AWSAccount()
+		if err != nil {
+			return err
+		}
+		if awsAccount.NativeID != testAcc.AccountID {
+			return fmt.Errorf("existing AWS account %q isn't expected test account %q, won't remove",
+				awsAccount.NativeID, testAcc.AccountID)
+		}
+		// TODO: we might need to iterate over awsAccount.Features to remove
+		// all of them in the future
+		return client.AWS().RemoveAccount(ctx, aws.Default(), core.FeatureCloudNativeProtection, false)
+	})
+
+	// Azure
+	g.Go(func() error {
+		testSub, err := testsetup.AzureSubscription()
+		if err != nil {
+			return err
+		}
+		azureAcc, err := client.Azure().Subscription(ctx, azure.SubscriptionID(testSub.SubscriptionID), core.FeatureAll)
+		switch {
+		case errors.Is(err, graphql.ErrNotFound):
+			return nil
+		case err != nil:
+			return fmt.Errorf("failed to check Azure subscription: %v", err)
+		}
+		if azureAcc.NativeID != testSub.SubscriptionID {
+			return fmt.Errorf("existing Azure subscription %q isn't the expected test subscription %q, won't remove",
+				azureAcc.NativeID, testSub.SubscriptionID)
+		}
+		// Azure doesn't automatically remove exocompute configs when removing
+		// the subscription so we need to do it manually here
+		exoCfgs, err := client.Azure().ExocomputeConfigs(ctx, azure.SubscriptionID(testSub.SubscriptionID))
+		if err != nil {
+			return err
+		}
+		for i := range exoCfgs {
+			if err := client.Azure().RemoveExocomputeConfig(ctx, exoCfgs[i].ID); err != nil {
+				return fmt.Errorf("failed to remove Azure ExocomputeConfig: %v", pretty.Sprint(exoCfgs[i]))
+			}
+		}
+
+		sub := azure.Subscription(testSub.SubscriptionID, testSub.TenantDomain)
+		// TODO: we might need to iterate over azureAcc.Features to remove
+		// all of them in the future
+		return client.Azure().RemoveSubscription(ctx, azure.ID(sub), core.FeatureCloudNativeProtection, false)
+	})
+
+	// GCP
+	g.Go(func() error {
+		testProj, err := testsetup.GCPProject()
+		if err != nil {
+			return err
+		}
+		proj, err := client.GCP().Project(ctx, gcp.ProjectID(testProj.ProjectID), core.FeatureAll)
+		switch {
+		case errors.Is(err, graphql.ErrNotFound):
+			return nil
+		case err != nil:
+			return fmt.Errorf("failed to check GCP project: %v", err)
+		}
+		if pn := proj.ProjectNumber; pn != testProj.ProjectNumber {
+			return fmt.Errorf("existing GCP project %q isn't expected test project %q, won't remove",
+				pn, testProj.ProjectNumber)
+		}
+		return client.GCP().RemoveProject(ctx, gcp.ProjectNumber(testProj.ProjectNumber), core.FeatureCloudNativeProtection, false)
+	})
+
+	return g.Wait()
+}

--- a/internal/testsetup/testsetup.go
+++ b/internal/testsetup/testsetup.go
@@ -1,0 +1,96 @@
+package testsetup
+
+import (
+	"encoding/json"
+	"fmt"
+	"os"
+
+	"github.com/google/uuid"
+)
+
+// testAwsAccount hold AWS account information used in the integration tests.
+// Normally used to assert that the information read from Polaris is correct.
+type testAwsAccount struct {
+	AccountID   string `json:"accountId"`
+	AccountName string `json:"accountName"`
+
+	Exocompute struct {
+		VPCID   string `json:"vpcId"`
+		Subnets []struct {
+			ID               string `json:"id"`
+			AvailabilityZone string `json:"availabilityZone"`
+		} `json:"subnets"`
+	} `json:"exocompute"`
+}
+
+// Load test account information from the file pointed to by the
+// TEST_AWSACCOUNT_FILE environment variable.
+func AWSAccount() (testAwsAccount, error) {
+	buf, err := os.ReadFile(os.Getenv("TEST_AWSACCOUNT_FILE"))
+	if err != nil {
+		return testAwsAccount{}, fmt.Errorf("failed to read file pointed to by TEST_AWSACCOUNT_FILE: %v", err)
+	}
+
+	testAccount := testAwsAccount{}
+	if err := json.Unmarshal(buf, &testAccount); err != nil {
+		return testAwsAccount{}, err
+	}
+
+	if n := len(testAccount.Exocompute.Subnets); n != 2 {
+		return testAwsAccount{}, fmt.Errorf("file contains the wrong number of subnets: %d", n)
+	}
+
+	return testAccount, nil
+}
+
+// testAzureSubscription hold Azure subscription information used in the
+// integration tests. Normally used to assert that the information read from
+// Polaris is correct.
+type testAzureSubscription struct {
+	SubscriptionID   uuid.UUID `json:"subscriptionId"`
+	SubscriptionName string    `json:"subscriptionName"`
+	TenantDomain     string    `json:"tenantDomain"`
+
+	Exocompute struct {
+		SubnetID string `json:"subnetId"`
+	} `json:"exocompute"`
+}
+
+// Load test project information from the file pointed to by the
+// TEST_AZURESUBSCRIPTION_FILE environment variable.
+func AzureSubscription() (testAzureSubscription, error) {
+	buf, err := os.ReadFile(os.Getenv("TEST_AZURESUBSCRIPTION_FILE"))
+	if err != nil {
+		return testAzureSubscription{}, fmt.Errorf("failed to read file pointed to by TEST_AZURESUBSCRIPTION_FILE: %v", err)
+	}
+
+	testSubscription := testAzureSubscription{}
+	if err := json.Unmarshal(buf, &testSubscription); err != nil {
+		return testAzureSubscription{}, err
+	}
+
+	return testSubscription, nil
+}
+
+// testGcpProject hold GCP project information used in the integration tests.
+// Normally used to assert that the information read from Polaris is correct.
+type testGcpProject struct {
+	ProjectName      string `json:"projectName"`
+	ProjectID        string `json:"projectId"`
+	ProjectNumber    int64  `json:"projectNumber"`
+	OrganizationName string `json:"organizationName"`
+}
+
+// Load test project information from the file pointed to by the
+// TEST_GCPPROJECT_FILE environment variable.
+func GCPProject() (testGcpProject, error) {
+	buf, err := os.ReadFile(os.Getenv("TEST_GCPPROJECT_FILE"))
+	if err != nil {
+		return testGcpProject{}, fmt.Errorf("failed to read file pointed to by TEST_GCPPROJECT_FILE: %v", err)
+	}
+	testProject := testGcpProject{}
+	if err := json.Unmarshal(buf, &testProject); err != nil {
+		return testGcpProject{}, err
+	}
+	return testProject, nil
+}


### PR DESCRIPTION
When the integration tests ran and failed there could be resources left
on the target system causing next run to fail.

This change adds a new internal command, testenv, that runs before and
after the CI test. Before it ensures that there are no resources around
that will fail the tests, and after it tries to remove resources left by
failed tests.
