### PR TITLE
Add missing err check in CloudAccountAddManualAuthProject

### DIFF
--- a/pkg/polaris/graphql/gcp/cloud.go
+++ b/pkg/polaris/graphql/gcp/cloud.go
@@ -97,8 +97,10 @@ func (a API) CloudAccountAddManualAuthProject(ctx context.Context, projectID, pr
 		OrgName   string       `json:"organizationName,omitempty"`
 		JwtConfig string       `json:"serviceAccountJwtConfigOptional,omitempty"`
 	}{Feature: feature, ID: projectID, Name: projectName, Number: projectNumber, OrgName: orgName, JwtConfig: jwtConfig})
-
-	return fmt.Errorf("failed to request CloudAccountAddManualAuthProject: %v", err)
+	if err != nil {
+		return fmt.Errorf("failed to request CloudAccountAddManualAuthProject: %v", err)
+	}
+	return nil
 }
 
 // CloudAccountDeleteProject delete cloud account for the given Polaris cloud


### PR DESCRIPTION
In #54 we accidentally introduced an unconditional error in
CloudAccountAddManualAuthProject by wrapping nil into an error. We now
check the error before returning.