### PR TITLE
Move setting of default log level out of NewClient

### DIFF
--- a/examples/aws_account/main.go
+++ b/examples/aws_account/main.go
@@ -44,7 +44,7 @@ func main() {
 	if err != nil {
 		log.Fatal(err)
 	}
-	client, err := polaris.NewClient(ctx, polAccount, &polaris_log.StandardLogger{})
+	client, err := polaris.NewClient(ctx, polAccount, polaris_log.NewStandardLogger())
 	if err != nil {
 		log.Fatal(err)
 	}

--- a/examples/aws_exocompute/main.go
+++ b/examples/aws_exocompute/main.go
@@ -39,7 +39,7 @@ func main() {
 	if err != nil {
 		log.Fatal(err)
 	}
-	client, err := polaris.NewClient(ctx, polAccount, &polaris_log.StandardLogger{})
+	client, err := polaris.NewClient(ctx, polAccount, polaris_log.NewStandardLogger())
 	if err != nil {
 		log.Fatal(err)
 	}

--- a/examples/azure_exocompute/main.go
+++ b/examples/azure_exocompute/main.go
@@ -40,7 +40,7 @@ func main() {
 	if err != nil {
 		log.Fatal(err)
 	}
-	client, err := polaris.NewClient(ctx, polAccount, &polaris_log.StandardLogger{})
+	client, err := polaris.NewClient(ctx, polAccount, polaris_log.NewStandardLogger())
 	if err != nil {
 		log.Fatal(err)
 	}

--- a/examples/azure_permissions/main.go
+++ b/examples/azure_permissions/main.go
@@ -46,7 +46,7 @@ func main() {
 	if err != nil {
 		log.Fatal(err)
 	}
-	client, err := polaris.NewClient(ctx, polAccount, &polaris_log.StandardLogger{})
+	client, err := polaris.NewClient(ctx, polAccount, polaris_log.NewStandardLogger())
 	if err != nil {
 		log.Fatal(err)
 	}

--- a/examples/azure_subscription/main.go
+++ b/examples/azure_subscription/main.go
@@ -45,7 +45,7 @@ func main() {
 	if err != nil {
 		log.Fatal(err)
 	}
-	client, err := polaris.NewClient(ctx, polAccount, &polaris_log.StandardLogger{})
+	client, err := polaris.NewClient(ctx, polAccount, polaris_log.NewStandardLogger())
 	if err != nil {
 		log.Fatal(err)
 	}

--- a/examples/gcp_permissions/main.go
+++ b/examples/gcp_permissions/main.go
@@ -45,7 +45,7 @@ func main() {
 	if err != nil {
 		log.Fatal(err)
 	}
-	client, err := polaris.NewClient(ctx, polAccount, &polaris_log.StandardLogger{})
+	client, err := polaris.NewClient(ctx, polAccount, polaris_log.NewStandardLogger())
 	if err != nil {
 		log.Fatal(err)
 	}

--- a/examples/gcp_project/main.go
+++ b/examples/gcp_project/main.go
@@ -44,7 +44,7 @@ func main() {
 	if err != nil {
 		log.Fatal(err)
 	}
-	client, err := polaris.NewClient(ctx, polAccount, &polaris_log.StandardLogger{})
+	client, err := polaris.NewClient(ctx, polAccount, polaris_log.NewStandardLogger())
 	if err != nil {
 		log.Fatal(err)
 	}

--- a/examples/gcp_project_with_set_sa/main.go
+++ b/examples/gcp_project_with_set_sa/main.go
@@ -45,7 +45,7 @@ func main() {
 	if err != nil {
 		log.Fatal(err)
 	}
-	client, err := polaris.NewClient(ctx, polAccount, &polaris_log.StandardLogger{})
+	client, err := polaris.NewClient(ctx, polAccount, polaris_log.NewStandardLogger())
 	if err != nil {
 		log.Fatal(err)
 	}

--- a/pkg/polaris/log/log.go
+++ b/pkg/polaris/log/log.go
@@ -116,6 +116,11 @@ type StandardLogger struct {
 	level LogLevel
 }
 
+// NewStandardLogger returns a standard logger with level set to Warn.
+func NewStandardLogger() *StandardLogger {
+	return &StandardLogger{level: Warn}
+}
+
 // SetLogLevel sets the log level to the specified level.
 func (l *StandardLogger) SetLogLevel(level LogLevel) {
 	l.level = level

--- a/pkg/polaris/log/log_test.go
+++ b/pkg/polaris/log/log_test.go
@@ -102,16 +102,27 @@ func TestStandardLogger(t *testing.T) {
 	buf := &bytes.Buffer{}
 	log.SetOutput(buf)
 
-	logger := StandardLogger{}
+	// Test that the default level is set to Warn
+	logger := NewStandardLogger()
+	logger.Print(Info, "Print")
+	logger.Print(Warn, "Print")
+	line, err := nextLine(buf)
+	if err != nil {
+		t.Fatal(err)
+	}
+	if line != "[WARN] polaris/log.TestStandardLogger Print" {
+		t.Fatalf("%q", line)
+	}
 
-	// Error and Fatal cannot be tested due to them aborting execution.
+	// Fatal cannot be tested due to them aborting execution.
 	logger.SetLogLevel(Info)
 	logger.Print(Trace, "Print")
 	logger.Print(Debug, "Print")
 	logger.Print(Info, "Print")
 	logger.Print(Warn, "Print")
+	logger.Print(Error, "Print")
 
-	line, err := nextLine(buf)
+	line, err = nextLine(buf)
 	if err != nil {
 		t.Fatal(err)
 	}
@@ -127,18 +138,34 @@ func TestStandardLogger(t *testing.T) {
 		t.Fatalf("%q", line)
 	}
 
-	// Error and Fatal cannot be tested due to them aborting execution.
+	line, err = nextLine(buf)
+	if err != nil {
+		t.Fatal(err)
+	}
+	if line != "[ERROR] polaris/log.TestStandardLogger Print" {
+		t.Fatalf("%q", line)
+	}
+
+	// Fatal cannot be tested due to them aborting execution.
 	logger.SetLogLevel(Warn)
 	logger.Printf(Trace, "Printf %q", "trace")
 	logger.Printf(Debug, "Printf %q", "debug")
 	logger.Printf(Info, "Printf %q", "info")
 	logger.Printf(Warn, "Printf %q", "warn")
+	logger.Printf(Error, "Printf %q", "error")
 
 	line, err = nextLine(buf)
 	if err != nil {
 		t.Fatal(err)
 	}
 	if line != "[WARN] polaris/log.TestStandardLogger Printf \"warn\"" {
+		t.Fatalf("%q", line)
+	}
+	line, err = nextLine(buf)
+	if err != nil {
+		t.Fatal(err)
+	}
+	if line != "[ERROR] polaris/log.TestStandardLogger Printf \"error\"" {
 		t.Fatalf("%q", line)
 	}
 }

--- a/pkg/polaris/polaris.go
+++ b/pkg/polaris/polaris.go
@@ -107,18 +107,16 @@ func newClientFromUserAccount(ctx context.Context, account *UserAccount, logger 
 		return nil, errors.New("invalid password")
 	}
 
-	logLevel := "warn"
 	if level := os.Getenv("RUBRIK_POLARIS_LOGLEVEL"); level != "" {
-		logLevel = level
-	}
-	if strings.ToLower(logLevel) != "off" {
-		level, err := log.ParseLogLevel(logLevel)
-		if err != nil {
-			return nil, fmt.Errorf("failed to parse log level: %v", err)
+		if strings.ToLower(level) != "off" {
+			l, err := log.ParseLogLevel(level)
+			if err != nil {
+				return nil, fmt.Errorf("failed to parse log level: %v", err)
+			}
+			logger.SetLogLevel(l)
+		} else {
+			logger = &log.DiscardLogger{}
 		}
-		logger.SetLogLevel(level)
-	} else {
-		logger = &log.DiscardLogger{}
 	}
 
 	logger.Printf(log.Info, "Polaris API URL: %s", apiURL)
@@ -159,18 +157,16 @@ func newClientFromServiceAccount(ctx context.Context, account *ServiceAccount, l
 		return nil, fmt.Errorf("invalid access token uri: %v", err)
 	}
 
-	logLevel := "warn"
 	if level := os.Getenv("RUBRIK_POLARIS_LOGLEVEL"); level != "" {
-		logLevel = level
-	}
-	if strings.ToLower(logLevel) != "off" {
-		level, err := log.ParseLogLevel(logLevel)
-		if err != nil {
-			return nil, fmt.Errorf("failed to parse log level: %v", err)
+		if strings.ToLower(level) != "off" {
+			l, err := log.ParseLogLevel(level)
+			if err != nil {
+				return nil, fmt.Errorf("failed to parse log level: %v", err)
+			}
+			logger.SetLogLevel(l)
+		} else {
+			logger = &log.DiscardLogger{}
 		}
-		logger.SetLogLevel(level)
-	} else {
-		logger = &log.DiscardLogger{}
 	}
 
 	// Extract the API URL from the token access URI.

--- a/pkg/polaris/polaris_test.go
+++ b/pkg/polaris/polaris_test.go
@@ -55,7 +55,7 @@ func TestMain(m *testing.M) {
 
 		// The integration tests defaults the log level to INFO. Note that
 		// RUBRIK_POLARIS_LOGLEVEL can be used to override this.
-		logger := &polaris_log.StandardLogger{}
+		logger := polaris_log.NewStandardLogger()
 		logger.SetLogLevel(polaris_log.Info)
 		client, err = NewClient(context.Background(), polAccount, logger)
 		if err != nil {


### PR DESCRIPTION
If a new client was created via NewClient and the log level wasn't set
using env-vari, it wasn't possible to provide a different level than the
default, warn. The NewClient call itself also logs at Info level so the
only way to see those logs were to use env override.

We now only override the provided loggers level if the env var is set.
This change also provides a NewStandardLogger() function that returns a
StandardLogger with the default level set (Warn).
