### PR TITLE
Use Info log level in internal/cmd/testenv

### DIFF
--- a/internal/cmd/testenv/main.go
+++ b/internal/cmd/testenv/main.go
@@ -36,7 +36,9 @@ func main() {
 	if err != nil {
 		log.Fatal(err)
 	}
-	client, err := polaris.NewClient(ctx, polAccount, &polaris_log.StandardLogger{})
+	logger := polaris_log.NewStandardLogger()
+	logger.SetLogLevel(polaris_log.Info)
+	client, err := polaris.NewClient(ctx, polAccount, logger)
 	if err != nil {
 		log.Fatal(err)
 	}


### PR DESCRIPTION
By changing log level in testenv to Info we will log Polaris version
(and endpoint) during client creation in the CI pipeline. Logging in
testenv will give us the version both before and after the integration
tests, something handy as the system under test could be upgraded at any
time.
