### PR TITLE
Address Polaris Azure API changes

### DIFF
--- a/pkg/polaris/graphql/azure/queries.go
+++ b/pkg/polaris/graphql/azure/queries.go
@@ -40,12 +40,41 @@ var addAzureCloudAccountExocomputeConfigurationsQuery = `mutation SdkGolangAddAz
 }`
 
 // addAzureCloudAccountWithoutOauth GraphQL query
-var addAzureCloudAccountWithoutOauthQuery = `mutation SdkGolangAddAzureCloudAccountWithoutOauth($tenantDomainName: String!, $azureCloudType: AzureCloudTypeEnum!, $regions: [AzureCloudAccountRegionEnum!]!, $features: [CloudAccountFeatureEnum!]!, $subscriptions: [AzureSubscriptionInput!]!, $policyVersion: Int!) {
+var addAzureCloudAccountWithoutOauthQuery = `mutation SdkGolangAddAzureCloudAccountWithoutOauth($tenantDomainName: String!, $azureCloudType: AzureCloudTypeEnum!, $regions: [AzureCloudAccountRegionEnum!]!, $feature: CloudAccountFeatureEnum!, $subscriptionName: String!, $subscriptionId: String!, $policyVersion: Int!) {
     result: addAzureCloudAccountWithoutOAuth(input: {
         tenantDomainName: $tenantDomainName,
         azureCloudType:   $azureCloudType,
-        features:         $features,
-        subscriptions:    $subscriptions,
+        subscriptions: {
+            subscription: {
+                name:     $subscriptionName,
+                nativeId: $subscriptionId
+            }
+            features: [{
+                featureType: $feature,
+            }]
+        },
+        regions:          $regions,
+        policyVersion:    $policyVersion
+    }) {
+        tenantId
+        status {
+            azureSubscriptionRubrikId
+            azureSubscriptionNativeId
+            error
+        }
+    }
+}`
+
+// addAzureCloudAccountWithoutOauthV0 GraphQL query
+var addAzureCloudAccountWithoutOauthV0Query = `mutation SdkGolangAddAzureCloudAccountWithoutOauthV0($tenantDomainName: String!, $azureCloudType: AzureCloudTypeEnum!, $regions: [AzureCloudAccountRegionEnum!]!, $feature: CloudAccountFeatureEnum!, $subscriptionName: String!, $subscriptionId: String!, $policyVersion: Int!) {
+    result: addAzureCloudAccountWithoutOAuth(input: {
+        tenantDomainName: $tenantDomainName,
+        azureCloudType:   $azureCloudType,
+        features:         [$feature],
+        subscriptions: {
+            name:     $subscriptionName,
+            nativeId: $subscriptionId
+        },
         regions:          $regions,
         policyVersion:    $policyVersion
     }) {

--- a/pkg/polaris/graphql/azure/queries/add_azure_cloud_account_without_oauth_v0.graphql
+++ b/pkg/polaris/graphql/azure/queries/add_azure_cloud_account_without_oauth_v0.graphql
@@ -2,14 +2,10 @@ mutation RubrikPolarisSDKRequest($tenantDomainName: String!, $azureCloudType: Az
     result: addAzureCloudAccountWithoutOAuth(input: {
         tenantDomainName: $tenantDomainName,
         azureCloudType:   $azureCloudType,
+        features:         [$feature],
         subscriptions: {
-            subscription: {
-                name:     $subscriptionName,
-                nativeId: $subscriptionId
-            }
-            features: [{
-                featureType: $feature,
-            }]
+            name:     $subscriptionName,
+            nativeId: $subscriptionId
         },
         regions:          $regions,
         policyVersion:    $policyVersion


### PR DESCRIPTION
The input parameters for the addAzureCloudAccountWithoutOAuth GraphQL
query has changed in preparation to support resource groups.