### PR TITLE
Fetch cdm token from service account

### DIFF
--- a/Jenkinsfile
+++ b/Jenkinsfile
@@ -48,6 +48,9 @@ pipeline {
 
         // Run integration tests with the nightly build.
         TEST_INTEGRATION = currentBuild.getBuildCauses('hudson.triggers.TimerTrigger$TimerTriggerCause').size()
+
+        // Appliance credentials
+        APPLIANCE_UUID = credentials('tf-appliance-uuid')
     }
     stages {
         stage('Lint') {

--- a/README.md
+++ b/README.md
@@ -244,3 +244,7 @@ correctly to Polaris:
 ```
 
 ![48332236-55506f00-e610-11e8-9a60-594de963a1ee](https://user-images.githubusercontent.com/2046831/119498600-1580ab80-bd66-11eb-87ca-c08df4eae15a.png)
+
+#### Appliance
+To run the appliance token exchange integration test, an appliance/cluster must already be registered to the Polaris instance and
+the environment variable `APPLIANCE_UUID` must be set to the UUID of the registered cluster.

--- a/pkg/polaris/appliance/appliance.go
+++ b/pkg/polaris/appliance/appliance.go
@@ -1,0 +1,76 @@
+// Copyright 2022 Rubrik, Inc.
+//
+// Permission is hereby granted, free of charge, to any person obtaining a copy
+// of this software and associated documentation files (the "Software"), to
+// deal in the Software without restriction, including without limitation the
+// rights to use, copy, modify, merge, publish, distribute, sublicense, and/or
+// sell copies of the Software, and to permit persons to whom the Software is
+// furnished to do so, subject to the following conditions:
+//
+// The above copyright notice and this permission notice shall be included in
+// all copies or substantial portions of the Software.
+//
+// THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+// IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+// FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+// AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+// LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING
+// FROM, OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER
+// DEALINGS IN THE SOFTWARE.
+
+// Package appliance enapsulates methods to help interact with Rubrik Appliance.
+package appliance
+
+import (
+	"encoding/json"
+	"errors"
+	"net/http"
+	"strings"
+
+	"github.com/google/uuid"
+
+	"github.com/rubrikinc/rubrik-polaris-sdk-for-go/pkg/polaris/token"
+	"github.com/rubrikinc/rubrik-polaris-sdk-for-go/pkg/polaris/log"
+	"github.com/rubrikinc/rubrik-polaris-sdk-for-go/pkg/polaris"
+)
+
+// ApplianceTokenFromServiceAccount returns a token to access appliance
+// REST APIs. It is issued on behalf of the given service account.
+func ApplianceTokenFromServiceAccount(account *polaris.ServiceAccount, clusterID uuid.UUID, logger log.Logger) (string, error) {
+	if !strings.HasSuffix(account.AccessTokenURI, "/client_token") {
+		return "", errors.New("invalid access token uri")
+	}
+	tokenURL := strings.TrimSuffix(account.AccessTokenURI, "/client_token") + "/cdm_client_token"
+
+	body, err := json.Marshal(struct {
+		ClientID		string `json:"client_id"`
+		ClientSecret	string `json:"client_secret"`
+		ClusterUuid		uuid.UUID `json:"cluster_uuid"`
+	}{ClientID: account.ClientID, ClientSecret: account.ClientSecret, ClusterUuid: clusterID})
+	if err != nil {
+		logger.Printf(log.Error, "failed to marshat token request body %v", err)	
+		return "", errors.New("internal: failed to marshal token request body")
+	}
+
+	resp, err := token.Request(http.DefaultClient, tokenURL, body, logger)
+	if err != nil {
+		return "", err
+	}
+
+	var payload struct {
+		Session struct {
+			AccessToken string `json:"token"`
+		}  `json:"session"`
+	}
+	if err := json.Unmarshal(resp, &payload); err != nil {
+		logger.Printf(log.Error, "failed to unmarshal cluster token response body %v", err)
+		return "", errors.New("failed to unmarshal token response body")
+	}
+
+	if payload.Session.AccessToken == "" {
+
+		return "", errors.New("invalid token")
+	}
+
+	return payload.Session.AccessToken, nil
+}


### PR DESCRIPTION
# Description
To support hybrid model, we are providing a method in SDK to fetch CDM/Appliance token using Polaris service account credential. This token can be used to call CDM / Appliance APIs either directly or using the CDM GO SDK.
 
## Motivation and Context

Why is this change required? What problem does it solve?
To shift our gears from 

## How Has This Been Tested?

Environment:
- Registered a CDM appliance to Polaris.

Test details:
- Called the ApplianceTokenFromServiceAccount method and verified that the returned token is valid.

## Screenshots (if appropriate):

## Types of changes

What types of changes does your code introduce? Put an `x` in all the boxes that apply:
- [ ] Bug fix (non-breaking change which fixes an issue)
- [X] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)

## Checklist:

Go over all the following points, and put an `x` in all the boxes that apply. If you're unsure about any of these, don't hesitate to ask. We're here to help!
- [X] My code follows the code style of this project.
- [ ] My change requires a change to the documentation.
- [X] I have updated the documentation accordingly.
- [ ] I have updated the CHANGELOG file accordingly for the version that this merge modifies.
- [ ] I have added tests to cover my changes.
- [ ] All new and existing tests passed.
