### PR TITLE
Fetch cdm token from service account

### DIFF
--- a/Jenkinsfile
+++ b/Jenkinsfile
@@ -32,6 +32,9 @@ pipeline {
         // Polaris credentials.
         RUBRIK_POLARIS_SERVICEACCOUNT_FILE = credentials('tf-sdk-test-polaris-service-account')
 
+        // Appliance credentials.
+        TEST_APPLIANCE_ID = credentials('tf-sdk-appliance-id')
+
         // AWS credentials.
         TEST_AWSACCOUNT_FILE        = credentials('tf-sdk-test-aws-account')
         AWS_SHARED_CREDENTIALS_FILE = credentials('tf-sdk-test-aws-credentials')

--- a/examples/appliance/main.go
+++ b/examples/appliance/main.go
@@ -1,0 +1,60 @@
+// Copyright 2022 Rubrik, Inc.
+//
+// Permission is hereby granted, free of charge, to any person obtaining a copy
+// of this software and associated documentation files (the "Software"), to
+// deal in the Software without restriction, including without limitation the
+// rights to use, copy, modify, merge, publish, distribute, sublicense, and/or
+// sell copies of the Software, and to permit persons to whom the Software is
+// furnished to do so, subject to the following conditions:
+//
+// The above copyright notice and this permission notice shall be included in
+// all copies or substantial portions of the Software.
+//
+// THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+// IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+// FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+// AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+// LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING
+// FROM, OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER
+// DEALINGS IN THE SOFTWARE.
+
+package main
+
+import (
+	"fmt"
+	"log"
+
+	"github.com/google/uuid"
+
+	"github.com/rubrikinc/rubrik-polaris-sdk-for-go/pkg/polaris"
+	"github.com/rubrikinc/rubrik-polaris-sdk-for-go/pkg/polaris/appliance"
+	polaris_log "github.com/rubrikinc/rubrik-polaris-sdk-for-go/pkg/polaris/log"
+)
+
+// Example showing how to request an appliance token using a service account
+// with the Go SDK.
+//
+// The Polaris service account key file identifying the Polaris account should
+// either be placed at ~/.rubrik/polaris-service-account.json or pointed out by
+// the RUBRIK_POLARIS_SERVICEACCOUNT_FILE environment variable.
+func main() {
+	serviceAccount, err := polaris.DefaultServiceAccount(true)
+	if err != nil {
+		log.Fatal(err)
+	}
+
+	// The appliance id. To run this example this needs to be changed to your
+	// appliance id.
+	applianceID, err := uuid.Parse("e71cc368-5fff-11ec-b6ac-df735a55e00f")
+	if err != nil {
+		log.Fatal(err)
+	}
+
+	// Request an appliance token using a standard service account.
+	token, err := appliance.TokenFromServiceAccount(serviceAccount, applianceID, polaris_log.NewStandardLogger())
+	if err != nil {
+		log.Fatal(err)
+	}
+
+	fmt.Printf("Appliance token: %s\n", token)
+}

--- a/internal/testsetup/boolenv.go
+++ b/internal/testsetup/boolenv.go
@@ -1,0 +1,35 @@
+// Copyright 2022 Rubrik, Inc.
+//
+// Permission is hereby granted, free of charge, to any person obtaining a copy
+// of this software and associated documentation files (the "Software"), to
+// deal in the Software without restriction, including without limitation the
+// rights to use, copy, modify, merge, publish, distribute, sublicense, and/or
+// sell copies of the Software, and to permit persons to whom the Software is
+// furnished to do so, subject to the following conditions:
+//
+// The above copyright notice and this permission notice shall be included in
+// all copies or substantial portions of the Software.
+//
+// THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+// IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+// FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+// AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+// LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING
+// FROM, OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER
+// DEALINGS IN THE SOFTWARE.
+
+package testsetup
+
+import (
+	"os"
+	"strconv"
+)
+
+// BoolEnvSet returns true if the provided argument is defined and true
+// according to the definition given by strconv.ParseBool.
+func BoolEnvSet(env string) bool {
+	val := os.Getenv(env)
+
+	b, err := strconv.ParseBool(val)
+	return err == nil && b
+}

--- a/pkg/polaris/appliance/appliance_token.go
+++ b/pkg/polaris/appliance/appliance_token.go
@@ -1,0 +1,74 @@
+// Copyright 2022 Rubrik, Inc.
+//
+// Permission is hereby granted, free of charge, to any person obtaining a copy
+// of this software and associated documentation files (the "Software"), to
+// deal in the Software without restriction, including without limitation the
+// rights to use, copy, modify, merge, publish, distribute, sublicense, and/or
+// sell copies of the Software, and to permit persons to whom the Software is
+// furnished to do so, subject to the following conditions:
+//
+// The above copyright notice and this permission notice shall be included in
+// all copies or substantial portions of the Software.
+//
+// THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+// IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+// FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+// AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+// LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING
+// FROM, OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER
+// DEALINGS IN THE SOFTWARE.
+
+package appliance
+
+import (
+	"encoding/json"
+	"errors"
+	"fmt"
+	"net/http"
+	"strings"
+
+	"github.com/google/uuid"
+
+	"github.com/rubrikinc/rubrik-polaris-sdk-for-go/pkg/polaris"
+	"github.com/rubrikinc/rubrik-polaris-sdk-for-go/pkg/polaris/log"
+	"github.com/rubrikinc/rubrik-polaris-sdk-for-go/pkg/polaris/token"
+)
+
+// TokenFromServiceAccount returns a token to access appliance APIs. This token
+// is issued on behalf of the given service account. Note that the service
+// account must have the appropriate role to access the appliance APIs.
+func TokenFromServiceAccount(account *polaris.ServiceAccount, applicanceID uuid.UUID, logger log.Logger) (string, error) {
+	tokenURL := account.AccessTokenURI
+	if !strings.HasSuffix(tokenURL, "/client_token") {
+		return "", errors.New("invalid access token uri")
+	}
+	tokenURL = strings.TrimSuffix(tokenURL, "/client_token") + "/cdm_client_token"
+
+	body, err := json.Marshal(struct {
+		ClientID     string    `json:"client_id"`
+		ClientSecret string    `json:"client_secret"`
+		ClusterID    uuid.UUID `json:"cluster_uuid"`
+	}{ClientID: account.ClientID, ClientSecret: account.ClientSecret, ClusterID: applicanceID})
+	if err != nil {
+		return "", fmt.Errorf("failed to marshal token request body: %v", err)
+	}
+
+	resp, err := token.Request(http.DefaultClient, tokenURL, body, logger)
+	if err != nil {
+		return "", fmt.Errorf("failed to acquire appliance access token: %v", err)
+	}
+
+	var payload struct {
+		Session struct {
+			AccessToken string `json:"token"`
+		} `json:"session"`
+	}
+	if err := json.Unmarshal(resp, &payload); err != nil {
+		return "", fmt.Errorf("failed to unmarshal token response body: %v", err)
+	}
+	if payload.Session.AccessToken == "" {
+		return "", errors.New("invalid token")
+	}
+
+	return payload.Session.AccessToken, err
+}

--- a/pkg/polaris/appliance/appliance_token_test.go
+++ b/pkg/polaris/appliance/appliance_token_test.go
@@ -1,0 +1,68 @@
+// Copyright 2022 Rubrik, Inc.
+//
+// Permission is hereby granted, free of charge, to any person obtaining a copy
+// of this software and associated documentation files (the "Software"), to
+// deal in the Software without restriction, including without limitation the
+// rights to use, copy, modify, merge, publish, distribute, sublicense, and/or
+// sell copies of the Software, and to permit persons to whom the Software is
+// furnished to do so, subject to the following conditions:
+//
+// The above copyright notice and this permission notice shall be included in
+// all copies or substantial portions of the Software.
+//
+// THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+// IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+// FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+// AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+// LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING
+// FROM, OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER
+// DEALINGS IN THE SOFTWARE.
+
+package appliance
+
+import (
+	"os"
+	"testing"
+
+	"github.com/google/uuid"
+
+	"github.com/rubrikinc/rubrik-polaris-sdk-for-go/internal/testsetup"
+	"github.com/rubrikinc/rubrik-polaris-sdk-for-go/pkg/polaris"
+	"github.com/rubrikinc/rubrik-polaris-sdk-for-go/pkg/polaris/log"
+)
+
+// TestApplianceTokenFromServiceAccount verifies that the SDK can retrieve
+// the API token for an appliance on behalf of a service account.
+//
+// To run this test against a Polaris instance the following environment
+// variable needs to be set:
+//  * RUBRIK_POLARIS_SERVICEACCOUNT_FILE=<path-to-polaris-service-account-file>
+// 	* TEST_INTEGRATION=1
+//  * TEST_APPLIANCE_ID=<appliance-uuid/cluster-uuid>
+//
+// In addition to the above environment variables, an appliance must be added to
+// the Polaris instance.
+func TestApplianceTokenFromServiceAccount(t *testing.T) {
+	if !testsetup.BoolEnvSet("TEST_INTEGRATION") {
+		t.Skipf("skipping due to env TEST_INTEGRATION not set")
+	}
+
+	// Load service account credentials. Usually resolved using the
+	// environment variable RUBRIK_POLARIS_SERVICEACCOUNT_FILE.
+	polAccount, err := polaris.DefaultServiceAccount(true)
+	if err != nil {
+		t.Fatal(err)
+	}
+	applianceID, err := uuid.Parse(os.Getenv("TEST_APPLIANCE_ID"))
+	if err != nil {
+		t.Fatal(err)
+	}
+
+	token, err := TokenFromServiceAccount(polAccount, applianceID, log.NewStandardLogger())
+	if err != nil {
+		t.Fatal(err)
+	}
+	if token == "" {
+		t.Fatal("TokenFromServiceAccount returned an empty token")
+	}
+}

--- a/pkg/polaris/polaris_test.go
+++ b/pkg/polaris/polaris_test.go
@@ -26,7 +26,6 @@ import (
 	"fmt"
 	"os"
 	"reflect"
-	"strconv"
 	"strings"
 	"testing"
 
@@ -45,7 +44,7 @@ import (
 var client *Client
 
 func TestMain(m *testing.M) {
-	if boolEnvSet("TEST_INTEGRATION") {
+	if testsetup.BoolEnvSet("TEST_INTEGRATION") {
 		// Load configuration and create client. Usually resolved using the
 		// environment variable RUBRIK_POLARIS_SERVICEACCOUNT_FILE.
 		polAccount, err := DefaultServiceAccount(true)
@@ -68,15 +67,6 @@ func TestMain(m *testing.M) {
 	os.Exit(m.Run())
 }
 
-// boolEnvSet returns true if the provided argument is defined and true
-// according to the definition given by strconv.ParseBool.
-func boolEnvSet(env string) bool {
-	val := os.Getenv(env)
-
-	b, err := strconv.ParseBool(val)
-	return err == nil && b
-}
-
 // TestAwsAccountAddAndRemove verifies that the SDK can perform the basic AWS
 // account operations on a real Polaris instance.
 //
@@ -91,7 +81,7 @@ func boolEnvSet(env string) bool {
 // The file referred to by TEST_AWSACCOUNT_FILE should contain a single
 // testAwsAccount JSON object.
 func TestAwsAccountAddAndRemove(t *testing.T) {
-	if !boolEnvSet("TEST_INTEGRATION") {
+	if !testsetup.BoolEnvSet("TEST_INTEGRATION") {
 		t.Skipf("skipping due to env TEST_INTEGRATION not set")
 	}
 
@@ -180,7 +170,7 @@ func TestAwsAccountAddAndRemove(t *testing.T) {
 // The file referred to by TEST_AWSACCOUNT_FILE should contain a single
 // testAwsAccount JSON object.
 func TestAwsExocompute(t *testing.T) {
-	if !boolEnvSet("TEST_INTEGRATION") {
+	if !testsetup.BoolEnvSet("TEST_INTEGRATION") {
 		t.Skipf("skipping due to env TEST_INTEGRATION not set")
 	}
 
@@ -321,7 +311,7 @@ func TestAwsExocompute(t *testing.T) {
 // The file referred to by TEST_AZURESUBSCRIPTION_FILE should contain a single
 // testAzureSubscription JSON object.
 func TestAzureSubscriptionAddAndRemove(t *testing.T) {
-	if !boolEnvSet("TEST_INTEGRATION") {
+	if !testsetup.BoolEnvSet("TEST_INTEGRATION") {
 		t.Skipf("skipping due to env TEST_INTEGRATION not set")
 	}
 
@@ -419,7 +409,7 @@ func TestAzureSubscriptionAddAndRemove(t *testing.T) {
 // The file referred to by TEST_AZURESUBSCRIPTION_FILE should contain a single
 // testAzureSubscription JSON object.
 func TestAzureExocompute(t *testing.T) {
-	if !boolEnvSet("TEST_INTEGRATION") {
+	if !testsetup.BoolEnvSet("TEST_INTEGRATION") {
 		t.Skipf("skipping due to env TEST_INTEGRATION not set")
 	}
 
@@ -551,7 +541,7 @@ func TestAzureExocompute(t *testing.T) {
 //   * RUBRIK_POLARIS_SERVICEACCOUNT_FILE=<path-to-polaris-service-account-file>
 //   * TEST_INTEGRATION=1
 func TestAzurePermissions(t *testing.T) {
-	if !boolEnvSet("TEST_INTEGRATION") {
+	if !testsetup.BoolEnvSet("TEST_INTEGRATION") {
 		t.Skipf("skipping due to env TEST_INTEGRATION not set")
 	}
 
@@ -586,7 +576,7 @@ func TestAzurePermissions(t *testing.T) {
 // The file referred to by TEST_GCPPROJECT_FILE should contain a single
 // testGcpProject JSON object.
 func TestGcpProjectAddAndRemove(t *testing.T) {
-	if !boolEnvSet("TEST_INTEGRATION") {
+	if !testsetup.BoolEnvSet("TEST_INTEGRATION") {
 		t.Skipf("skipping due to env TEST_INTEGRATION not set")
 	}
 
@@ -658,7 +648,7 @@ func TestGcpProjectAddAndRemove(t *testing.T) {
 // The file referred to by TEST_GCPPROJECT_FILE should contain a single
 // testGcpProject JSON object.
 func TestGcpProjectAddAndRemoveWithServiceAccountSet(t *testing.T) {
-	if !boolEnvSet("TEST_INTEGRATION") {
+	if !testsetup.BoolEnvSet("TEST_INTEGRATION") {
 		t.Skipf("skipping due to env TEST_INTEGRATION not set")
 	}
 
@@ -729,7 +719,7 @@ func TestGcpProjectAddAndRemoveWithServiceAccountSet(t *testing.T) {
 //   * RUBRIK_POLARIS_SERVICEACCOUNT_FILE=<path-to-polaris-service-account-file>
 //   * TEST_INTEGRATION=1
 func TestGcpPermissions(t *testing.T) {
-	if !boolEnvSet("TEST_INTEGRATION") {
+	if !testsetup.BoolEnvSet("TEST_INTEGRATION") {
 		t.Skipf("skipping due to env TEST_INTEGRATION not set")
 	}
 


### PR DESCRIPTION

# Description
To support hybrid model, we are providing a method in SDK to fetch CDM/Appliance token using Polaris service account credential. This token can be used to call CDM / Appliance APIs either directly or using the CDM GO SDK.
 
## Motivation and Context

Why is this change required? What problem does it solve?
To shift our gears from 

## How Has This Been Tested?

Environment:
- Registered a CDM appliance to Polaris.

Test details:
- Called the ApplianceTokenFromServiceAccount method and verified that the returned token is valid.

## Screenshots (if appropriate):

## Types of changes

What types of changes does your code introduce? Put an `x` in all the boxes that apply:
- [ ] Bug fix (non-breaking change which fixes an issue)
- [X] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)

## Checklist:

Go over all the following points, and put an `x` in all the boxes that apply. If you're unsure about any of these, don't hesitate to ask. We're here to help!
- [X] My code follows the code style of this project.
- [ ] My change requires a change to the documentation.
- [X] I have updated the documentation accordingly.
- [ ] I have updated the CHANGELOG file accordingly for the version that this merge modifies.
- [ ] I have added tests to cover my changes.
- [ ] All new and existing tests passed.
