### PR TITLE
Update AddSubscription for Azure Archival and Archival Encryption

### DIFF
--- a/internal/testsetup/testsetup.go
+++ b/internal/testsetup/testsetup.go
@@ -55,6 +55,15 @@ type testAzureSubscription struct {
 	Exocompute struct {
 		SubnetID string `json:"subnetId"`
 	} `json:"exocompute"`
+
+	// should be in EastUS2 region
+	// for integration test
+	// as region is hardcoded there.
+	Archival struct {
+		ManagedIdentityName string `json:"managedIdentityName"`
+		PrincipalID         string `json:"managedIdentityPrincipalId"`
+		ResourceGroupName   string `json:"resourceGroupName"`
+	} `json:"archival"`
 }
 
 // Load test project information from the file pointed to by the

--- a/pkg/polaris/graphql/azure/azure.go
+++ b/pkg/polaris/graphql/azure/azure.go
@@ -32,7 +32,6 @@ import (
 	"strings"
 
 	"github.com/google/uuid"
-
 	"github.com/rubrikinc/rubrik-polaris-sdk-for-go/pkg/polaris/graphql"
 	"github.com/rubrikinc/rubrik-polaris-sdk-for-go/pkg/polaris/log"
 )

--- a/pkg/polaris/graphql/azure/queries.go
+++ b/pkg/polaris/graphql/azure/queries.go
@@ -40,7 +40,7 @@ var addAzureCloudAccountExocomputeConfigurationsQuery = `mutation SdkGolangAddAz
 }`
 
 // addAzureCloudAccountWithoutOauth GraphQL query
-var addAzureCloudAccountWithoutOauthQuery = `mutation SdkGolangAddAzureCloudAccountWithoutOauth($tenantDomainName: String!, $azureCloudType: AzureCloudTypeEnum!, $regions: [AzureCloudAccountRegionEnum!]!, $feature: CloudAccountFeatureEnum!, $subscriptionName: String!, $subscriptionId: String!, $policyVersion: Int!) {
+var addAzureCloudAccountWithoutOauthQuery = `mutation SdkGolangAddAzureCloudAccountWithoutOauth($tenantDomainName: String!, $azureCloudType: AzureCloudTypeEnum!, $regions: [AzureCloudAccountRegionEnum!]!, $feature: AddAzureCloudAccountFeatureInputWithoutOauth!, $subscriptionName: String!, $subscriptionId: String!) {
     result: addAzureCloudAccountWithoutOAuth(input: {
         tenantDomainName: $tenantDomainName,
         azureCloudType:   $azureCloudType,
@@ -49,10 +49,7 @@ var addAzureCloudAccountWithoutOauthQuery = `mutation SdkGolangAddAzureCloudAcco
                 name:     $subscriptionName,
                 nativeId: $subscriptionId
             }
-            features: [{
-                featureType:   $feature,
-                policyVersion: $policyVersion,
-            }]
+            features: [$feature]
         },
         regions:          $regions,
     }) {

--- a/pkg/polaris/graphql/azure/queries/add_azure_cloud_account_without_oauth.graphql
+++ b/pkg/polaris/graphql/azure/queries/add_azure_cloud_account_without_oauth.graphql
@@ -1,4 +1,4 @@
-mutation RubrikPolarisSDKRequest($tenantDomainName: String!, $azureCloudType: AzureCloudTypeEnum!, $regions: [AzureCloudAccountRegionEnum!]!, $feature: CloudAccountFeatureEnum!, $subscriptionName: String!, $subscriptionId: String!, $policyVersion: Int!) {
+mutation RubrikPolarisSDKRequest($tenantDomainName: String!, $azureCloudType: AzureCloudTypeEnum!, $regions: [AzureCloudAccountRegionEnum!]!, $feature: AddAzureCloudAccountFeatureInputWithoutOauth!, $subscriptionName: String!, $subscriptionId: String!) {
     result: addAzureCloudAccountWithoutOAuth(input: {
         tenantDomainName: $tenantDomainName,
         azureCloudType:   $azureCloudType,
@@ -7,10 +7,7 @@ mutation RubrikPolarisSDKRequest($tenantDomainName: String!, $azureCloudType: Az
                 name:     $subscriptionName,
                 nativeId: $subscriptionId
             }
-            features: [{
-                featureType:   $feature,
-                policyVersion: $policyVersion,
-            }]
+            features: [$feature]
         },
         regions:          $regions,
     }) {

--- a/pkg/polaris/graphql/core/core.go
+++ b/pkg/polaris/graphql/core/core.go
@@ -52,16 +52,17 @@ const (
 type Feature string
 
 const (
-	FeatureInvalid               Feature = ""
-	FeatureAll                   Feature = "ALL"
-	FeatureAppFlows              Feature = "APP_FLOWS"
-	FeatureArchival              Feature = "ARCHIVAL"
-	FeatureCloudAccounts         Feature = "CLOUDACCOUNTS"
-	FeatureCloudNativeArchival   Feature = "CLOUD_NATIVE_ARCHIVAL"
-	FeatureCloudNativeProtection Feature = "CLOUD_NATIVE_PROTECTION"
-	FeatureExocompute            Feature = "EXOCOMPUTE"
-	FeatureGCPSharedVPCHost      Feature = "GCP_SHARED_VPC_HOST"
-	FeatureRDSProtection         Feature = "RDS_PROTECTION"
+	FeatureInvalid                       Feature = ""
+	FeatureAll                           Feature = "ALL"
+	FeatureAppFlows                      Feature = "APP_FLOWS"
+	FeatureArchival                      Feature = "ARCHIVAL"
+	FeatureCloudAccounts                 Feature = "CLOUDACCOUNTS"
+	FeatureCloudNativeArchival           Feature = "CLOUD_NATIVE_ARCHIVAL"
+	FeatureCloudNativeArchivalEncryption Feature = "CLOUD_NATIVE_ARCHIVAL_ENCRYPTION"
+	FeatureCloudNativeProtection         Feature = "CLOUD_NATIVE_PROTECTION"
+	FeatureExocompute                    Feature = "EXOCOMPUTE"
+	FeatureGCPSharedVPCHost              Feature = "GCP_SHARED_VPC_HOST"
+	FeatureRDSProtection                 Feature = "RDS_PROTECTION"
 )
 
 var validFeatures = map[Feature]struct{}{


### PR DESCRIPTION
# Description

Updated the GraphQL query `addAzureCloudAccountWithoutOAuth` to use the updated Polaris schema.
Added support to include Azure archival account creation and archival encryption.
Added support to input resource group to be used for cloud account
and custom key to be used for encryption.

## Motivation and Context

This was required to match Polaris capabilities to drive Archival from Go SDK as well.

## How Has This Been Tested?
Run the existing integration test and add/run new tests for Archival and Archival Encryption.
Existing tests run:
`TestAzureSubscriptionAddAndRemove`
New added/run:
`TestAzureArchivalSubscriptionAddAndRemove`
`TestAzureArchivalEncryptionSubscriptionAddAndRemove`

Verified on `https://arpitk-sdk-test.dev-064.my.rubrik-lab.com/api` polaris instance with user `arpitk-gal@rubrik.com`

## Types of changes

- New feature added for Azure Archival and Archival Encryption cloud account creation.

## Checklist:

Go over all the following points, and put an `x` in all the boxes that apply. If you're unsure about any of these, don't hesitate to ask. We're here to help!
- [x] My code follows the code style of this project.
- [ ] My change requires a change to the documentation.
- [ ] I have updated the documentation accordingly.
- [ ] I have updated the CHANGELOG file accordingly for the version that this merge modifies.
- [x] I have added tests to cover my changes.
- [x] All new and existing tests passed.
