### PR TITLE
Remove ErrNotUnique

### DIFF
--- a/pkg/polaris/aws/aws.go
+++ b/pkg/polaris/aws/aws.go
@@ -116,14 +116,15 @@ func (a API) toCloudAccountID(ctx context.Context, id IdentityFunc) (uuid.UUID, 
 	if err != nil {
 		return uuid.Nil, fmt.Errorf("failed to get account: %v", err)
 	}
-	if len(accountsWithFeatures) < 1 {
-		return uuid.Nil, fmt.Errorf("account %w", graphql.ErrNotFound)
-	}
-	if len(accountsWithFeatures) > 1 {
-		return uuid.Nil, fmt.Errorf("account %w", graphql.ErrNotUnique)
+
+	// Find the exact match.
+	for _, accountWithFeatures := range accountsWithFeatures {
+		if accountWithFeatures.Account.NativeID == identity.id {
+			return accountWithFeatures.Account.ID, nil
+		}
 	}
 
-	return accountsWithFeatures[0].Account.ID, nil
+	return uuid.Nil, fmt.Errorf("account %w", graphql.ErrNotFound)
 }
 
 // toNativeID returns the AWS account id for the specified identity. If the
@@ -201,6 +202,7 @@ func (a API) Account(ctx context.Context, id IdentityFunc, feature core.Feature)
 			return CloudAccount{}, fmt.Errorf("failed to get account: %v", err)
 		}
 
+		// Find the exact match.
 		for _, accountWithFeatures := range accountsWithFeatures {
 			if accountWithFeatures.Account.ID == cloudAccountID {
 				return toCloudAccount(accountWithFeatures), nil
@@ -211,11 +213,12 @@ func (a API) Account(ctx context.Context, id IdentityFunc, feature core.Feature)
 		if err != nil {
 			return CloudAccount{}, fmt.Errorf("failed to get account: %v", err)
 		}
-		if len(accountsWithFeatures) == 1 {
-			return toCloudAccount(accountsWithFeatures[0]), nil
-		}
-		if len(accountsWithFeatures) > 1 {
-			return CloudAccount{}, fmt.Errorf("account %w", graphql.ErrNotUnique)
+
+		// Find the exact match.
+		for _, accountWithFeatures := range accountsWithFeatures {
+			if accountWithFeatures.Account.NativeID == identity.id {
+				return toCloudAccount(accountWithFeatures), nil
+			}
 		}
 	}
 

--- a/pkg/polaris/gcp/identity.go
+++ b/pkg/polaris/gcp/identity.go
@@ -29,9 +29,17 @@ import (
 	"github.com/google/uuid"
 )
 
+type identityKind int
+
+const (
+	internalID identityKind = iota
+	externalID
+	externalNumber
+)
+
 type identity struct {
-	id       string
-	internal bool
+	id   string
+	kind identityKind
 }
 
 // IdentityFunc returns a project identity initialized from the values passed
@@ -42,7 +50,7 @@ type IdentityFunc func(ctx context.Context) (identity, error)
 // the specified Polaris cloud account id.
 func CloudAccountID(id uuid.UUID) IdentityFunc {
 	return func(ctx context.Context) (identity, error) {
-		return identity{id: id.String(), internal: true}, nil
+		return identity{id: id.String(), kind: internalID}, nil
 	}
 }
 
@@ -55,7 +63,7 @@ func ID(project ProjectFunc) IdentityFunc {
 			return identity{}, fmt.Errorf("failed to lookup project: %v", err)
 		}
 
-		return identity{id: config.id, internal: false}, nil
+		return identity{id: config.id, kind: externalID}, nil
 	}
 }
 
@@ -67,7 +75,7 @@ func ProjectID(id string) IdentityFunc {
 			return identity{}, errors.New("invalid GCP project id")
 		}
 
-		return identity{id: id, internal: false}, nil
+		return identity{id: id, kind: externalID}, nil
 	}
 }
 
@@ -75,6 +83,6 @@ func ProjectID(id string) IdentityFunc {
 // specified project number.
 func ProjectNumber(number int64) IdentityFunc {
 	return func(ctx context.Context) (identity, error) {
-		return identity{id: strconv.FormatInt(number, 10), internal: false}, nil
+		return identity{id: strconv.FormatInt(number, 10), kind: externalNumber}, nil
 	}
 }

--- a/pkg/polaris/graphql/aws/native.go
+++ b/pkg/polaris/graphql/aws/native.go
@@ -132,8 +132,8 @@ func (a API) NativeAccounts(ctx context.Context, feature ProtectionFeature, filt
 	return accounts, nil
 }
 
-// StartNativeAccountDisableJob starts a task chain job to disables the native
-// account with the specified Polaris native account id. Returns the Polaris
+// StartNativeAccountDisableJob starts a task chain job to disable the native
+// account with the specified Polaris cloud account id. Returns the Polaris
 // task chain id.
 func (a API) StartNativeAccountDisableJob(ctx context.Context, id uuid.UUID, feature ProtectionFeature, deleteSnapshots bool) (uuid.UUID, error) {
 	a.GQL.Log().Print(log.Trace)

--- a/pkg/polaris/graphql/azure/native.go
+++ b/pkg/polaris/graphql/azure/native.go
@@ -32,6 +32,8 @@ import (
 )
 
 // NativeSubscription represents a Polaris native subscription.
+// NativeSubscriptions are connected to CloudAccounts through the NativeID
+// field.
 type NativeSubscription struct {
 	ID            uuid.UUID          `json:"id"`
 	Name          string             `json:"name"`

--- a/pkg/polaris/graphql/errors.go
+++ b/pkg/polaris/graphql/errors.go
@@ -25,7 +25,4 @@ import "errors"
 var (
 	// ErrNotFound signals that the specified entity could not be found.
 	ErrNotFound = errors.New("not found")
-
-	// ErrNotUnique signals that a request did not result in a unique entity.
-	ErrNotUnique = errors.New("not unique")
 )

--- a/pkg/polaris/graphql/gcp/native.go
+++ b/pkg/polaris/graphql/gcp/native.go
@@ -33,7 +33,8 @@ import (
 	"github.com/rubrikinc/rubrik-polaris-sdk-for-go/pkg/polaris/log"
 )
 
-// NativeProject represents a Polaris native project.
+// NativeProject represents a Polaris native project. NativeProjects are
+// connected to CloudAccounts through the NativeID field.
 type NativeProject struct {
 	ID               uuid.UUID          `json:"id"`
 	Name             string             `json:"name"`

--- a/pkg/polaris/polaris_test.go
+++ b/pkg/polaris/polaris_test.go
@@ -867,6 +867,14 @@ func TestGcpProjectAddAndRemove(t *testing.T) {
 		t.Errorf("invalid number of features: %v", n)
 	}
 
+	// Verify that the Project function does not return a project given a prefix
+	// of the project id.
+	prefix := testProject.ProjectID[:len(testProject.ProjectID)/2]
+	account, err = client.GCP().Project(ctx, gcp.ProjectID(prefix), core.FeatureCloudNativeProtection)
+	if !errors.Is(err, graphql.ErrNotFound) {
+		t.Fatalf("invalid error: %v", err)
+	}
+
 	// Remove GCP project from Polaris keeping the snapshots.
 	err = client.GCP().RemoveProject(ctx, gcp.ID(gcp.Default()), core.FeatureCloudNativeProtection, false)
 	if err != nil {


### PR DESCRIPTION
Instead of returning ErrNotUnique if a search for an id returns
multiple entities we always search the returned entities for an exact
match.