### PR TITLE
Change ID type from uuid.UUID to string

### DIFF
--- a/pkg/polaris/graphql/aws/exocompute.go
+++ b/pkg/polaris/graphql/aws/exocompute.go
@@ -39,12 +39,12 @@ type Subnet struct {
 
 // ExocomputeConfig represents a single exocompute config.
 type ExocomputeConfig struct {
-	ID      uuid.UUID `json:"configUuid"`
-	Region  Region    `json:"region"`
-	VPCID   string    `json:"vpcId"`
-	Subnet1 Subnet    `json:"subnet1"`
-	Subnet2 Subnet    `json:"subnet2"`
-	Message string    `json:"message"`
+	ID      string `json:"configUuid"`
+	Region  Region `json:"region"`
+	VPCID   string `json:"vpcId"`
+	Subnet1 Subnet `json:"subnet1"`
+	Subnet2 Subnet `json:"subnet2"`
+	Message string `json:"message"`
 
 	// When true Polaris manages the security groups.
 	IsManagedByRubrik bool `json:"areSecurityGroupsRscManaged"`


### PR DESCRIPTION
If there is an error when creating an AWS exocompute configuration, an empty string is returned for the configuration ID. This causes the unmarshaling of the GraphQL response to fail. This in turn looses the GraphQL message field, containing details about the cause of the exocompute configuration failure.
