### PR TITLE
Allow more subnets in aws testsetup file

### DIFF
--- a/internal/testsetup/testsetup.go
+++ b/internal/testsetup/testsetup.go
@@ -40,7 +40,7 @@ func AWSAccount() (testAwsAccount, error) {
 		return testAwsAccount{}, err
 	}
 
-	if n := len(testAccount.Exocompute.Subnets); n != 2 {
+	if n := len(testAccount.Exocompute.Subnets); n < 2 {
 		return testAwsAccount{}, fmt.Errorf("file contains the wrong number of subnets: %d", n)
 	}
 


### PR DESCRIPTION
We need to allow more than 2 aws exocompute subnets configured in the testaccount file to be able to update CI before merging #140.