### PR TITLE
Fix an issue with AWS exocompute customer supplied security groups

### DIFF
--- a/pkg/polaris/aws/exocompute.go
+++ b/pkg/polaris/aws/exocompute.go
@@ -178,11 +178,11 @@ func Unmanaged(region, vpcID string, subnetIDs []string, clusterSecurityGroupID,
 		}
 
 		// Validate security groups.
-		if hasSecurityGroup(vpc, clusterSecurityGroupID) {
+		if !hasSecurityGroup(vpc, clusterSecurityGroupID) {
 			return aws.ExocomputeConfigCreate{},
 				fmt.Errorf("invalid cluster security group id: %v", clusterSecurityGroupID)
 		}
-		if hasSecurityGroup(vpc, nodeSecurityGroupID) {
+		if !hasSecurityGroup(vpc, nodeSecurityGroupID) {
 			return aws.ExocomputeConfigCreate{},
 				fmt.Errorf("invalid node security group id: %v", nodeSecurityGroupID)
 		}


### PR DESCRIPTION
When creating the exocompute configuration, the supplied security groups was checked to exist, but the boolean condition was inverted.