### PR TITLE
Use RSC_MANAGED_CLUSTER permission group

### DIFF
--- a/pkg/polaris/aws/exocompute_test.go
+++ b/pkg/polaris/aws/exocompute_test.go
@@ -68,7 +68,8 @@ func TestAwsExocompute(t *testing.T) {
 	}
 
 	// Enable the exocompute feature for the account.
-	exoAccountID, err := awsClient.AddAccount(ctx, Profile(testAccount.Profile), []core.Feature{core.FeatureExocompute},
+	exoAccountID, err := awsClient.AddAccount(ctx, Profile(testAccount.Profile),
+		[]core.Feature{core.FeatureExocompute.WithPermissionGroups(core.PermissionGroupBasic, core.PermissionGroupRSCManagedCluster)},
 		Regions("us-east-2"))
 	if err != nil {
 		t.Fatal(err)


### PR DESCRIPTION
When running the exocompute unit tests the RSC_MANAGED_CLUSTER permission group must be specified when onboarding the EXOCOMPUTE feature.
