### PR TITLE
Extend AddClusterToExocomputeConfig to return setup YAML

### DIFF
--- a/pkg/polaris/aws/exocompute.go
+++ b/pkg/polaris/aws/exocompute.go
@@ -26,10 +26,9 @@ import (
 	"fmt"
 
 	"github.com/google/uuid"
-	"github.com/rubrikinc/rubrik-polaris-sdk-for-go/pkg/polaris/graphql/exocompute"
-
 	"github.com/rubrikinc/rubrik-polaris-sdk-for-go/pkg/polaris/graphql"
 	"github.com/rubrikinc/rubrik-polaris-sdk-for-go/pkg/polaris/graphql/aws"
+	"github.com/rubrikinc/rubrik-polaris-sdk-for-go/pkg/polaris/graphql/exocompute"
 	"github.com/rubrikinc/rubrik-polaris-sdk-for-go/pkg/polaris/log"
 )
 
@@ -408,13 +407,15 @@ func (a API) UnmapExocompute(ctx context.Context, appID IdentityFunc) error {
 }
 
 // AddClusterToExocomputeConfig adds the named cluster to specified exocompute
-// configuration. The cluster ID and connection command are returned.
-func (a API) AddClusterToExocomputeConfig(ctx context.Context, configID uuid.UUID, clusterName string) (uuid.UUID, string, error) {
+// configuration. The cluster ID and two different ways to connect the cluster
+// are returned. The first way to connect the cluster is the kubectl connection
+// command, and the second way is the k8s spec (YAML).
+func (a API) AddClusterToExocomputeConfig(ctx context.Context, configID uuid.UUID, clusterName string) (uuid.UUID, []string, error) {
 	a.log.Print(log.Trace)
 
 	clusterID, cmd, err := aws.Wrap(a.client).ConnectExocomputeCluster(ctx, configID, clusterName)
 	if err != nil {
-		return uuid.Nil, "", fmt.Errorf("failed to connect exocompute cluster: %s", err)
+		return uuid.Nil, nil, fmt.Errorf("failed to connect exocompute cluster: %s", err)
 	}
 
 	return clusterID, cmd, nil

--- a/pkg/polaris/aws/exocompute.go
+++ b/pkg/polaris/aws/exocompute.go
@@ -410,15 +410,15 @@ func (a API) UnmapExocompute(ctx context.Context, appID IdentityFunc) error {
 // configuration. The cluster ID and two different ways to connect the cluster
 // are returned. The first way to connect the cluster is the kubectl connection
 // command, and the second way is the k8s spec (YAML).
-func (a API) AddClusterToExocomputeConfig(ctx context.Context, configID uuid.UUID, clusterName string) (uuid.UUID, []string, error) {
+func (a API) AddClusterToExocomputeConfig(ctx context.Context, configID uuid.UUID, clusterName string) (uuid.UUID, string, string, error) {
 	a.log.Print(log.Trace)
 
-	clusterID, cmd, err := aws.Wrap(a.client).ConnectExocomputeCluster(ctx, configID, clusterName)
+	clusterID, kubectlCmd, setupYAML, err := aws.Wrap(a.client).ConnectExocomputeCluster(ctx, configID, clusterName)
 	if err != nil {
-		return uuid.Nil, nil, fmt.Errorf("failed to connect exocompute cluster: %s", err)
+		return uuid.Nil, "", "", fmt.Errorf("failed to connect exocompute cluster: %s", err)
 	}
 
-	return clusterID, cmd, nil
+	return clusterID, kubectlCmd, setupYAML, nil
 }
 
 // RemoveExocomputeCluster removes the exocompute cluster with the specified ID.

--- a/pkg/polaris/graphql/aws/exocompute.go
+++ b/pkg/polaris/graphql/aws/exocompute.go
@@ -261,8 +261,10 @@ func (a API) StartExocomputeDisableJob(ctx context.Context, nativeID uuid.UUID) 
 }
 
 // ConnectExocomputeCluster connects the named cluster to a specified exocompute
-// configuration. The cluster ID and connection command are returned.
-func (a API) ConnectExocomputeCluster(ctx context.Context, configID uuid.UUID, clusterName string) (uuid.UUID, string, error) {
+// configuration. The cluster ID and two different ways to connect the cluster
+// are returned. The first way to connect the cluster is the kubectl connection
+// command, and the second way is the k8s spec (YAML).
+func (a API) ConnectExocomputeCluster(ctx context.Context, configID uuid.UUID, clusterName string) (uuid.UUID, []string, error) {
 	a.log.Print(log.Trace)
 
 	buf, err := a.GQL.Request(ctx, awsExocomputeClusterConnectQuery, struct {
@@ -270,23 +272,24 @@ func (a API) ConnectExocomputeCluster(ctx context.Context, configID uuid.UUID, c
 		ClusterName string    `json:"clusterName"`
 	}{ConfigID: configID, ClusterName: clusterName})
 	if err != nil {
-		return uuid.Nil, "", fmt.Errorf("failed to request awsExocomputeClusterConnect: %w", err)
+		return uuid.Nil, nil, fmt.Errorf("failed to request awsExocomputeClusterConnect: %w", err)
 	}
 	a.log.Printf(log.Debug, "awsExocomputeClusterConnect(%q, %q): %s", configID, clusterName, string(buf))
 
 	var payload struct {
 		Data struct {
 			Result struct {
-				ID      uuid.UUID `json:"clusterUuid"`
-				Command string    `json:"connectionCommand"`
+				ID        uuid.UUID `json:"clusterUuid"`
+				Command   string    `json:"connectionCommand"`
+				SetupYAML string    `json:"clusterSetupYaml"`
 			} `json:"result"`
 		} `json:"data"`
 	}
 	if err := json.Unmarshal(buf, &payload); err != nil {
-		return uuid.Nil, "", fmt.Errorf("failed to unmarshal awsExocomputeClusterConnect: %v", err)
+		return uuid.Nil, nil, fmt.Errorf("failed to unmarshal awsExocomputeClusterConnect: %v", err)
 	}
 
-	return payload.Data.Result.ID, payload.Data.Result.Command, nil
+	return payload.Data.Result.ID, []string{payload.Data.Result.Command, payload.Data.Result.SetupYAML}, nil
 }
 
 // DisconnectExocomputeCluster disconnects the exocompute cluster with the

--- a/pkg/polaris/graphql/aws/exocompute.go
+++ b/pkg/polaris/graphql/aws/exocompute.go
@@ -264,7 +264,7 @@ func (a API) StartExocomputeDisableJob(ctx context.Context, nativeID uuid.UUID) 
 // configuration. The cluster ID and two different ways to connect the cluster
 // are returned. The first way to connect the cluster is the kubectl connection
 // command, and the second way is the k8s spec (YAML).
-func (a API) ConnectExocomputeCluster(ctx context.Context, configID uuid.UUID, clusterName string) (uuid.UUID, []string, error) {
+func (a API) ConnectExocomputeCluster(ctx context.Context, configID uuid.UUID, clusterName string) (uuid.UUID, string, string, error) {
 	a.log.Print(log.Trace)
 
 	buf, err := a.GQL.Request(ctx, awsExocomputeClusterConnectQuery, struct {
@@ -272,7 +272,7 @@ func (a API) ConnectExocomputeCluster(ctx context.Context, configID uuid.UUID, c
 		ClusterName string    `json:"clusterName"`
 	}{ConfigID: configID, ClusterName: clusterName})
 	if err != nil {
-		return uuid.Nil, nil, fmt.Errorf("failed to request awsExocomputeClusterConnect: %w", err)
+		return uuid.Nil, "", "", fmt.Errorf("failed to request awsExocomputeClusterConnect: %w", err)
 	}
 	a.log.Printf(log.Debug, "awsExocomputeClusterConnect(%q, %q): %s", configID, clusterName, string(buf))
 
@@ -286,10 +286,10 @@ func (a API) ConnectExocomputeCluster(ctx context.Context, configID uuid.UUID, c
 		} `json:"data"`
 	}
 	if err := json.Unmarshal(buf, &payload); err != nil {
-		return uuid.Nil, nil, fmt.Errorf("failed to unmarshal awsExocomputeClusterConnect: %v", err)
+		return uuid.Nil, "", "", fmt.Errorf("failed to unmarshal awsExocomputeClusterConnect: %v", err)
 	}
 
-	return payload.Data.Result.ID, []string{payload.Data.Result.Command, payload.Data.Result.SetupYAML}, nil
+	return payload.Data.Result.ID, payload.Data.Result.Command, payload.Data.Result.SetupYAML, nil
 }
 
 // DisconnectExocomputeCluster disconnects the exocompute cluster with the

--- a/pkg/polaris/graphql/aws/queries.go
+++ b/pkg/polaris/graphql/aws/queries.go
@@ -201,6 +201,7 @@ var awsExocomputeClusterConnectQuery = `mutation SdkGolangAwsExocomputeClusterCo
         clusterName:        $clusterName,
         exocomputeConfigId: $exocomputeConfigId
     }) {
+        clusterSetupYaml
         clusterUuid
         connectionCommand
     }

--- a/pkg/polaris/graphql/aws/queries/aws_exocompute_cluster_connect.graphql
+++ b/pkg/polaris/graphql/aws/queries/aws_exocompute_cluster_connect.graphql
@@ -3,6 +3,7 @@ mutation RubrikPolarisSDKRequest($clusterName: String!, $exocomputeConfigId: UUI
         clusterName:        $clusterName,
         exocomputeConfigId: $exocomputeConfigId
     }) {
+        clusterSetupYaml
         clusterUuid
         connectionCommand
     }


### PR DESCRIPTION
AddClusterToExocomputeConfig now returns both the kubectl connection command and the cluster setup YAML.