### PR TITLE
Add functions to look up cloud accounts by native ID and name

### DIFF
--- a/pkg/polaris/access/role.go
+++ b/pkg/polaris/access/role.go
@@ -90,7 +90,7 @@ func (a API) RoleByName(ctx context.Context, name string) (Role, error) {
 
 	role, err := findRoleByName(roles, name)
 	if err != nil {
-		return Role{}, fmt.Errorf("failed to find role: %w", err)
+		return Role{}, err
 	}
 
 	return role, nil
@@ -105,7 +105,7 @@ func findRoleByName(roles []Role, name string) (Role, error) {
 		}
 	}
 
-	return Role{}, fmt.Errorf("role with name %q %w", name, graphql.ErrNotFound)
+	return Role{}, fmt.Errorf("role %q %w", name, graphql.ErrNotFound)
 }
 
 // Roles returns the roles matching the specified role name filter. The name
@@ -188,7 +188,7 @@ func (a API) RoleTemplateByName(ctx context.Context, name string) (RoleTemplate,
 
 	roleTemplate, err := findRoleTemplateByName(roleTemplates, name)
 	if err != nil {
-		return RoleTemplate{}, fmt.Errorf("failed to find role template: %v", err)
+		return RoleTemplate{}, err
 	}
 
 	return roleTemplate, nil
@@ -203,7 +203,7 @@ func findRoleTemplateByName(roleTemplates []RoleTemplate, name string) (RoleTemp
 		}
 	}
 
-	return RoleTemplate{}, fmt.Errorf("role template with name %q %w", name, graphql.ErrNotFound)
+	return RoleTemplate{}, fmt.Errorf("role template %q %w", name, graphql.ErrNotFound)
 }
 
 // RoleTemplates returns the role templates matching the specified role template

--- a/pkg/polaris/aws/aws.go
+++ b/pkg/polaris/aws/aws.go
@@ -236,6 +236,43 @@ func (a API) Account(ctx context.Context, id IdentityFunc, feature core.Feature)
 	return CloudAccount{}, fmt.Errorf("account %w", graphql.ErrNotFound)
 }
 
+// AccountByNativeID returns the account with the specified feature and native
+// ID.
+func (a API) AccountByNativeID(ctx context.Context, feature core.Feature, nativeID string) (CloudAccount, error) {
+	a.log.Print(log.Trace)
+
+	accounts, err := a.Accounts(ctx, feature, nativeID)
+	if err != nil {
+		return CloudAccount{}, fmt.Errorf("failed to get account by native id: %s", err)
+	}
+
+	for _, account := range accounts {
+		if account.NativeID == nativeID {
+			return account, nil
+		}
+	}
+
+	return CloudAccount{}, fmt.Errorf("account %q %w", nativeID, graphql.ErrNotFound)
+}
+
+// AccountByName returns the account with the specified feature and name.
+func (a API) AccountByName(ctx context.Context, feature core.Feature, name string) (CloudAccount, error) {
+	a.log.Print(log.Trace)
+
+	accounts, err := a.Accounts(ctx, feature, name)
+	if err != nil {
+		return CloudAccount{}, fmt.Errorf("failed to get account by name: %s", err)
+	}
+
+	for _, account := range accounts {
+		if account.Name == name {
+			return account, nil
+		}
+	}
+
+	return CloudAccount{}, fmt.Errorf("account %q %w", name, graphql.ErrNotFound)
+}
+
 // Accounts return all accounts with the specified feature matching the filter.
 // The filter can be used to search for account id, account name and role arn.
 func (a API) Accounts(ctx context.Context, feature core.Feature, filter string) ([]CloudAccount, error) {


### PR DESCRIPTION
The functions have been added for AWS accounts and Azure subscriptions.