### PR TITLE
Disable post-quantum crypto algorithms in CI

### DIFF
--- a/Jenkinsfile
+++ b/Jenkinsfile
@@ -73,6 +73,17 @@ pipeline {
 
         // Enable trace logging.
         RUBRIK_POLARIS_LOGLEVEL = "${params.LOG_LEVEL}"
+
+        // Recent versions of Go added support for post-quantum cryptography algorithms
+        // x25519Kyber768Draft00 (Go 1.23) and X25519MLKEM768 (Go 1.24, where Kyber
+        // was removed). Both of them are enabled by default, but that causes
+        // TLS timeout issues against some systems like Palo Alto
+        // that can't handle the increased size of ClientHello-messages.
+        // With these enabled the ClientHello message spans two TCP frames instead
+        // of just one with them disabled.
+        //
+        // We use GODEBUG to disable both here to cover for both Go 1.23 and Go 1.24.
+        GODEBUG = "tlskyber=0,tlsmlkem=0"
     }
     stages {
         stage('Lint') {


### PR DESCRIPTION
# Description

Recent versions of Go added support for post-quantum cryptography algorithms
x25519Kyber768Draft00 (Go 1.23) and X25519MLKEM768 (Go 1.24, where Kyber
was removed). Both of them are enabled by default, but that causes
TLS timeout issues against some systems like Palo Alto
that can't handle the increased size of ClientHello-messages.
With these enabled the ClientHello message spans two TCP frames instead
of just one with them disabled.

We use GODEBUG to disable both here to cover for both Go 1.23 and Go 1.24.
