### PR TITLE
Log Go version used in CI

### DIFF
--- a/Jenkinsfile
+++ b/Jenkinsfile
@@ -23,6 +23,8 @@
 pipeline {
     agent any
     tools {
+        // Note that this version is only used to bootstrap the version
+        // specified in go.mod.
         go 'go-1.22'
     }
     triggers {
@@ -88,6 +90,7 @@ pipeline {
     stages {
         stage('Lint') {
             steps {
+                sh 'go version' // Log Go version used.
                 sh 'go mod tidy'
                 sh 'go vet ./...'
                 sh 'go run honnef.co/go/tools/cmd/staticcheck@v0.6.1 ./...'


### PR DESCRIPTION
# Description

Add a log entry with the Go version used when running CI.