### PR TITLE
Run cleanup if precheck fail in CI

### DIFF
--- a/Jenkinsfile
+++ b/Jenkinsfile
@@ -105,7 +105,7 @@ pipeline {
         stage('Pre-test') {
             when { expression { env.TEST_INTEGRATION == "true" } }
             steps {
-                sh 'go run ./cmd/testenv -precheck'
+                sh 'go run ./cmd/testenv -cleanup'
             }
         }
         stage('Test') {


### PR DESCRIPTION
# Description

As we always run cleanup we might as well do it _before_ running the tests, if the precheck fail.
This change adds support for running testenv with both flags enabled and updates the Jenkinsfile to do so.