### PR TITLE
Use logger instance in standard logger instead of the global one

### DIFF
--- a/pkg/polaris/log/log_test.go
+++ b/pkg/polaris/log/log_test.go
@@ -3,7 +3,6 @@ package log
 import (
 	"bytes"
 	"errors"
-	"log"
 	"strings"
 	"testing"
 )
@@ -100,10 +99,10 @@ func TestParseLogLevel(t *testing.T) {
 
 func TestStandardLogger(t *testing.T) {
 	buf := &bytes.Buffer{}
-	log.SetOutput(buf)
 
 	// Test that the default level is set to Warn
 	logger := NewStandardLogger()
+	logger.SetOutput(buf)
 	logger.Print(Info, "Print")
 	logger.Print(Warn, "Print")
 	line, err := nextLine(buf)


### PR DESCRIPTION
# Description

Instead of using the global logger that other packages could reconfigure we now create a separate instance of the stdlib log logger. We also configure it with higher resolution for timestamps to aid debugging.

It includes modernize suggestions to use `any` instead of `interface{}` and a minor fix to one of the comments.

## How Has This Been Tested?

Ran tests locally and observed the output.

## Types of changes

What types of changes does your code introduce? Put an `x` in all the boxes that apply:
- [ ] Bug fix (non-breaking change which fixes an issue)
- [x] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)

## Checklist:

Go over all the following points, and put an `x` in all the boxes that apply. If you're unsure about any of these, don't hesitate to ask. We're here to help!
- [x] My code follows the code style of this project.
- [ ] My change requires a change to the documentation.
- [ ] I have updated the documentation accordingly.
- [ ] I have updated the CHANGELOG file accordingly for the version that this merge modifies.
- [ ] I have added tests to cover my changes.
- [x] All new and existing tests passed.
