### PR TITLE
Add cloudType to the finalizeAwsCloudAccountProtection query

### DIFF
--- a/cmd/testenv/main.go
+++ b/cmd/testenv/main.go
@@ -230,7 +230,7 @@ func clean(ctx context.Context, client *polaris.Client, provider string) error {
 			// Remove all features for the subscription.
 			for _, feature := range azureAcc.Features {
 				if err := azureClient.RemoveSubscription(ctx, azure.CloudAccountID(azureAcc.ID), feature.Feature, false); err != nil {
-					return fmt.Errorf("failed to remove Azure cloud account fetaure %v: %s", feature.Name, err)
+					return fmt.Errorf("failed to remove Azure cloud account feature %v: %s", feature.Name, err)
 				}
 			}
 

--- a/pkg/polaris/graphql/aws/queries.go
+++ b/pkg/polaris/graphql/aws/queries.go
@@ -191,19 +191,30 @@ var finalizeAwsCloudAccountDeletionQuery = `mutation SdkGolangFinalizeAwsCloudAc
 }`
 
 // finalizeAwsCloudAccountProtection GraphQL query
-var finalizeAwsCloudAccountProtectionQuery = `mutation SdkGolangFinalizeAwsCloudAccountProtection($nativeId: String!, $accountName: String!, $awsRegions: [AwsCloudAccountRegion!], $externalId: String!, $featureVersion: [AwsCloudAccountFeatureVersionInput!]!, $features: [CloudAccountFeature!], $featuresWithPG: [FeatureWithPermissionsGroups!], $stackName: String!) {
+var finalizeAwsCloudAccountProtectionQuery = `mutation SdkGolangFinalizeAwsCloudAccountProtection(
+    $nativeId:       String!,
+    $accountName:    String!,
+    $awsRegions:     [AwsCloudAccountRegion!],
+    $externalId:     String!,
+    $featureVersion: [AwsCloudAccountFeatureVersionInput!]!,
+    $features:       [CloudAccountFeature!],
+    $featuresWithPG: [FeatureWithPermissionsGroups!],
+    $stackName:      String!,
+    $cloudType:      AwsCloudType,
+) {
     finalizeAwsCloudAccountProtection(input: {
         action: CREATE,
         awsChildAccounts: [{
             accountName: $accountName,
-            nativeId: $nativeId,
+            cloudType:   $cloudType,
+            nativeId:    $nativeId,
         }],
-        awsRegions: $awsRegions,
-        externalId: $externalId,
-        featureVersion: $featureVersion,
-        features: $features,
+        awsRegions:                    $awsRegions,
+        externalId:                    $externalId,
+        featureVersion:                $featureVersion,
+        features:                      $features,
         featuresWithPermissionsGroups: $featuresWithPG,
-        stackName: $stackName,
+        stackName:                     $stackName,
     }) {
        awsChildAccounts {
            accountName

--- a/pkg/polaris/graphql/aws/queries/finalize_aws_cloud_account_protection.graphql
+++ b/pkg/polaris/graphql/aws/queries/finalize_aws_cloud_account_protection.graphql
@@ -1,16 +1,27 @@
-mutation RubrikPolarisSDKRequest($nativeId: String!, $accountName: String!, $awsRegions: [AwsCloudAccountRegion!], $externalId: String!, $featureVersion: [AwsCloudAccountFeatureVersionInput!]!, $features: [CloudAccountFeature!], $featuresWithPG: [FeatureWithPermissionsGroups!], $stackName: String!) {
+mutation RubrikPolarisSDKRequest(
+    $nativeId:       String!,
+    $accountName:    String!,
+    $awsRegions:     [AwsCloudAccountRegion!],
+    $externalId:     String!,
+    $featureVersion: [AwsCloudAccountFeatureVersionInput!]!,
+    $features:       [CloudAccountFeature!],
+    $featuresWithPG: [FeatureWithPermissionsGroups!],
+    $stackName:      String!,
+    $cloudType:      AwsCloudType,
+) {
     finalizeAwsCloudAccountProtection(input: {
         action: CREATE,
         awsChildAccounts: [{
             accountName: $accountName,
-            nativeId: $nativeId,
+            cloudType:   $cloudType,
+            nativeId:    $nativeId,
         }],
-        awsRegions: $awsRegions,
-        externalId: $externalId,
-        featureVersion: $featureVersion,
-        features: $features,
+        awsRegions:                    $awsRegions,
+        externalId:                    $externalId,
+        featureVersion:                $featureVersion,
+        features:                      $features,
         featuresWithPermissionsGroups: $featuresWithPG,
-        stackName: $stackName,
+        stackName:                     $stackName,
     }) {
        awsChildAccounts {
            accountName

--- a/pkg/polaris/graphql/core/core.go
+++ b/pkg/polaris/graphql/core/core.go
@@ -25,6 +25,7 @@
 package core
 
 import (
+	"cmp"
 	"context"
 	"encoding/json"
 	"errors"
@@ -461,6 +462,9 @@ func (a API) EnabledFeaturesForAccount(ctx context.Context) ([]Feature, error) {
 	for _, feature := range payload.Data.Result.Features {
 		features = append(features, Feature{Name: feature})
 	}
+	slices.SortFunc(features, func(i, j Feature) int {
+		return cmp.Compare(i.Name, j.Name)
+	})
 
 	return features, nil
 }


### PR DESCRIPTION
# Description

The finalizeAwsCloudAccountProtection query was missing the cloudType parameter. This caused it to default to STANDARD, which would break the onboarding of AWS Gov accounts.

In addition, the EnabledFeaturesForAccount function has been updated to sort the result it returns.

## Related Issue

https://github.com/rubrikinc/terraform-provider-polaris/issues/251

## How Has This Been Tested?

Manually onboarded an AWS Gov account to RSC-G. Ran the integration test suite.

## Types of changes

What types of changes does your code introduce? Put an `x` in all the boxes that apply:
- [X] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)

## Checklist:

Go over all the following points, and put an `x` in all the boxes that apply. If you're unsure about any of these, don't hesitate to ask. We're here to help!
- [X] My code follows the code style of this project.
- [ ] My change requires a change to the documentation.
- [ ] I have updated the documentation accordingly.
- [ ] I have updated the CHANGELOG file accordingly for the version that this merge modifies.
- [ ] I have added tests to cover my changes.
- [X] All new and existing tests passed.
