### PR TITLE
Fix Feature Names

### DIFF
--- a/pkg/polaris/graphql/core/core.go
+++ b/pkg/polaris/graphql/core/core.go
@@ -160,8 +160,8 @@ var (
 	FeatureCloudNativeBlobProtection               = Feature{Name: "CLOUD_NATIVE_BLOB_PROTECTION"}
 	FeatureCloudNativeProtection                   = Feature{Name: "CLOUD_NATIVE_PROTECTION"}
 	FeatureCloudNativeS3Protection                 = Feature{Name: "CLOUD_NATIVE_S3_PROTECTION"}
-	FeatureCyberRecoveryDataClassificationData     = Feature{Name: "CYBER_RECOVERY_DATA_CLASSIFICATION_DATA"}
-	FeatureCyberRecoveryDataClassificationMetadata = Feature{Name: "CYBER_RECOVERY_DATA_CLASSIFICATION_METADATA"}
+	FeatureCyberRecoveryDataClassificationData     = Feature{Name: "CYBERRECOVERY_DATA_CLASSIFICATION_DATA"}
+	FeatureCyberRecoveryDataClassificationMetadata = Feature{Name: "CYBERRECOVERY_DATA_CLASSIFICATION_METADATA"}
 	FeatureDSPMData                                = Feature{Name: "DSPM_DATA"}
 	FeatureDSPMMetadata                            = Feature{Name: "DSPM_METADATA"}
 	FeatureExocompute                              = Feature{Name: "EXOCOMPUTE"}


### PR DESCRIPTION
# Description

Ensure feature names are API compliant.

## Related Issue

Terraform Provider throws an error regarding API validation
```
Variable '$featuresWithPG' expected value of type '[FeatureWithPermissionsGroups!]' but got: [{"featureType":"CYBER_RECOVERY_DATA_CLASSIFICATION_DATA","permissionsGroups":["BASIC"]},{"featureType":"CYBER_RECOVERY_DATA_CLASSIFICATION_METADATA","permissionsGroups":["BASIC"]}]. Reason: '[0].featureType' Enum value 'CYBER_RECOVERY_DATA_CLASSIFICATION_METADATA' is undefined in enum type 'CloudAccountFeature'.  Known values are: CYBERRECOVERY_DATA_CLASSIFICATION_METADATA, CYBERRECOVERY_DATA_CLASSIFICATION_DATA
```

## How Has This Been Tested?

Called API directly with SDK.

## Types of changes

What types of changes does your code introduce? Put an `x` in all the boxes that apply:
- [X] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)

## Checklist:

Go over all the following points, and put an `x` in all the boxes that apply. If you're unsure about any of these, don't hesitate to ask. We're here to help!
- [X] My code follows the code style of this project.
- [X] My change requires a change to the documentation.
- [X] I have updated the documentation accordingly.
- [X] I have updated the CHANGELOG file accordingly for the version that this merge modifies.
- [X] I have added tests to cover my changes.
- [X] All new and existing tests passed.
