### PR TITLE
Add support for reading a single feature flag

### DIFF
--- a/examples/feature_flags/main.go
+++ b/examples/feature_flags/main.go
@@ -62,4 +62,12 @@ func main() {
 			fmt.Println(flag.Name)
 		}
 	}
+
+	// Fetch single feature flag.
+	featureFlag, err := core.Wrap(client.GQL).FeatureFlag(ctx, "GPS_DASH_V2_ENABLED")
+	if err != nil {
+		log.Fatal(err)
+	}
+
+	fmt.Printf("Feature flag %s is %v\n", featureFlag.Name, featureFlag.Enabled)
 }

--- a/pkg/polaris/graphql/core/queries.go
+++ b/pkg/polaris/graphql/core/queries.go
@@ -41,6 +41,14 @@ var deploymentVersionQuery = `query SdkGolangDeploymentVersion {
     deploymentVersion
 }`
 
+// featureFlag GraphQL query
+var featureFlagQuery = `query SdkGolangFeatureFlag($flagName: FeatureFlagName!) {
+  featureFlag(flagName: $flagName, entityType: ACCOUNT, entityContext: []) {
+    name
+    variant
+  }
+}`
+
 // featureFlagAll GraphQL query
 var featureFlagAllQuery = `query SdkGolangFeatureFlagAll {
     result: featureFlagAll(entityType: ACCOUNT, entityContext: []) {

--- a/pkg/polaris/graphql/core/queries/feature_flag.graphql
+++ b/pkg/polaris/graphql/core/queries/feature_flag.graphql
@@ -1,0 +1,6 @@
+query RubrikPolarisSDKRequest($flagName: FeatureFlagName!) {
+  featureFlag(flagName: $flagName, entityType: ACCOUNT, entityContext: []) {
+    name
+    variant
+  }
+}


### PR DESCRIPTION
# Description

This change adds support for fetching a specific RSC feature flag.

## Motivation and Context

Fetching all feature flags transfers high amount of data, especially if it is done several times like the terraform provider often does.

## How Has This Been Tested?

Ran updated example.

## Screenshots (if appropriate):

## Types of changes

What types of changes does your code introduce? Put an `x` in all the boxes that apply:
- [ ] Bug fix (non-breaking change which fixes an issue)
- [x] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)

## Checklist:

Go over all the following points, and put an `x` in all the boxes that apply. If you're unsure about any of these, don't hesitate to ask. We're here to help!
- [x] My code follows the code style of this project.
- [ ] My change requires a change to the documentation.
- [ ] I have updated the documentation accordingly.
- [ ] I have updated the CHANGELOG file accordingly for the version that this merge modifies.
- [ ] I have added tests to cover my changes.
- [x] All new and existing tests passed.
