### PR TITLE
Pass empty struct as schema query variables

### DIFF
--- a/cmd/schema/main.go
+++ b/cmd/schema/main.go
@@ -153,7 +153,7 @@ func main() {
 		log.Fatal(err)
 	}
 
-	buf, err := client.GQL.Request(context.Background(), schemaQuery, nil)
+	buf, err := client.GQL.Request(context.Background(), schemaQuery, struct{}{})
 	if err != nil {
 		log.Fatal(err)
 	}


### PR DESCRIPTION
## Description

Pass `struct{}{}` instead of `nil` as variables to the schema introspection query so the debug log
shows `{}` instead of `null`.

## How Has This Been Tested?

By running `cmd/schema` with `RUBRIK_POLARIS_LOGLEVEL=debug`.

## Types of changes

What types of changes does your code introduce? Put an `x` in all the boxes that apply:
- [X] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)

## Checklist:

Go over all the following points, and put an `x` in all the boxes that apply. If you're unsure about any of these, don't hesitate to ask. We're here to help!
- [X] My code follows the code style of this project.
- [ ] My change requires a change to the documentation.
- [ ] I have updated the documentation accordingly.
- [ ] I have updated the CHANGELOG file accordingly for the version that this merge modifies.
- [ ] I have added tests to cover my changes.
- [X] All new and existing tests passed.