### PR TITLE
Add retry support for HTTP-level errors

### DIFF
--- a/pkg/polaris/graphql/errors.go
+++ b/pkg/polaris/graphql/errors.go
@@ -23,6 +23,7 @@ package graphql
 import (
 	"errors"
 	"fmt"
+	"net/http"
 	"strings"
 )
 
@@ -30,6 +31,23 @@ var (
 	// ErrNotFound signals that the specified entity could not be found.
 	ErrNotFound = errors.New("not found")
 )
+
+// httpError represents an HTTP-level error with a status code.
+type httpError struct {
+	statusCode int
+	msg        string
+}
+
+func (e httpError) Error() string {
+	return e.msg
+}
+
+// isTemporary returns true if the HTTP status code indicates a temporary
+// condition that may resolve on retry.
+func (e httpError) isTemporary() bool {
+	return e.statusCode == http.StatusBadGateway || e.statusCode == http.StatusServiceUnavailable ||
+		e.statusCode == http.StatusGatewayTimeout || e.statusCode == http.StatusTooManyRequests
+}
 
 // GQLError is returned by RSC in the body of a response as a JSON document when
 // certain types of GraphQL errors occur.

--- a/pkg/polaris/graphql/graphql.go
+++ b/pkg/polaris/graphql/graphql.go
@@ -57,10 +57,11 @@ import (
 
 // Client is used to make GraphQL calls to the Polaris platform.
 type Client struct {
-	Version string // Deprecated: use DeploymentVersion.
-	gqlURL  string
-	client  *http.Client
-	log     log.Logger
+	Version    string // Deprecated: use DeploymentVersion.
+	retryDelay time.Duration
+	gqlURL     string
+	client     *http.Client
+	log        log.Logger
 }
 
 // Build into is used to derive SDK metrics headers.
@@ -207,16 +208,23 @@ func (c *Client) RequestWithoutLogging(ctx context.Context, query string, variab
 	for {
 		buf, err := c.RequestWithoutRetry(ctx, query, variables)
 
-		var gqlErr GQLError
-		if errors.As(err, &gqlErr) && gqlErr.isTemporary() {
+		var tempErr interface {
+			error
+			isTemporary() bool
+		}
+		if errors.As(err, &tempErr) && tempErr.isTemporary() {
 			if retryAttempt++; retryAttempt > requestRetryAttempts {
 				return nil, fmt.Errorf("request failed after %d retries: %w", retryAttempt-1, err)
 			}
 
 			c.log.Printf(log.Debug, "Endpoint temporarily unavailable (retry attempt: %d/%d): %s", retryAttempt,
 				requestRetryAttempts, err)
+			delay := c.retryDelay
+			if delay == 0 {
+				delay = 10 * time.Second
+			}
 			select {
-			case <-time.After(10 * time.Second):
+			case <-time.After(delay):
 				continue
 			case <-ctx.Done():
 				return nil, ctx.Err()
@@ -292,16 +300,19 @@ func (c *Client) RequestWithoutRetry(ctx context.Context, query string, variable
 	}
 	defer res.Body.Close()
 
-	// Remote responded without a body. For status code 200, this means we
-	// are missing the GraphQL response. For an error, we have no additional
-	// details.
-	if res.ContentLength == 0 {
-		return nil, fmt.Errorf("graphql response has no body (status code %d)", res.StatusCode)
-	}
-
 	buf, err = io.ReadAll(res.Body)
 	if err != nil {
 		return nil, fmt.Errorf("failed to read graphql response body (status code %d): %v", res.StatusCode, err)
+	}
+
+	// Remote responded without a body. For status code 200, this means we
+	// are missing the GraphQL response. For an error, we have no additional
+	// details.
+	if len(buf) == 0 {
+		return nil, httpError{
+			statusCode: res.StatusCode,
+			msg:        fmt.Sprintf("graphql response has no body (status code %d)", res.StatusCode),
+		}
 	}
 
 	// Verify that the content type of the body is JSON. For status code 200,
@@ -313,8 +324,11 @@ func (c *Client) RequestWithoutRetry(ctx context.Context, query string, variable
 		if len(snippet) > 512 {
 			snippet = snippet[:512]
 		}
-		return nil, fmt.Errorf("graphql response has Content-Type %s (status code %d): %q",
-			contentType, res.StatusCode, snippet)
+		return nil, httpError{
+			statusCode: res.StatusCode,
+			msg: fmt.Sprintf("graphql response has Content-Type %s (status code %d): %q",
+				contentType, res.StatusCode, snippet),
+		}
 	}
 
 	// Remote responded with a JSON document. Try to parse it as both known
@@ -338,7 +352,10 @@ func (c *Client) RequestWithoutRetry(ctx context.Context, query string, variable
 	}
 
 	if res.StatusCode != 200 {
-		return nil, fmt.Errorf("graphql response has status code: %s", res.Status)
+		return nil, httpError{
+			statusCode: res.StatusCode,
+			msg:        fmt.Sprintf("graphql response has status code: %s", res.Status),
+		}
 	}
 
 	return buf, nil

--- a/pkg/polaris/graphql/graphql_test.go
+++ b/pkg/polaris/graphql/graphql_test.go
@@ -27,6 +27,7 @@ import (
 	"strings"
 	"testing"
 	"text/template"
+	"time"
 
 	"github.com/rubrikinc/rubrik-polaris-sdk-for-go/internal/assert"
 	"github.com/rubrikinc/rubrik-polaris-sdk-for-go/internal/handler"
@@ -111,6 +112,41 @@ func TestRequestWithInternalServerErrorTextBody(t *testing.T) {
 	_, err := NewTestClient(srv).Request(context.Background(), "me { name }", nil)
 	if err == nil || !strings.HasSuffix(err.Error(), "graphql response has Content-Type text/plain (status code 500): \"database is corrupt\"") {
 		t.Fatalf("invalid error: %v", err)
+	}
+}
+
+func TestRequestWithBadGatewayRetry(t *testing.T) {
+	ctx, cancel := context.WithCancelCause(context.Background())
+	defer assert.Context(t, ctx, cancel)
+
+	// First request responds with a 502, second request succeeds.
+	attempt := 0
+	srv := httptest.NewServer(handler.Token(func(w http.ResponseWriter, req *http.Request) {
+		attempt++
+		if attempt == 1 {
+			w.Header().Set("Content-Type", "text/html; charset=UTF-8")
+			w.WriteHeader(502)
+			w.Write([]byte("<html><body>502 Bad Gateway</body></html>"))
+			return
+		}
+
+		w.Header().Set("Content-Type", "application/json")
+		w.Write([]byte(`{"data":{"result":"ok"}}`))
+	}))
+	defer srv.Close()
+
+	client := NewTestClient(srv)
+	client.retryDelay = 10 * time.Millisecond
+
+	buf, err := client.Request(ctx, "me { name }", nil)
+	if err != nil {
+		t.Fatalf("expected retry to succeed, got error: %v", err)
+	}
+	if !strings.Contains(string(buf), `"result":"ok"`) {
+		t.Fatalf("unexpected response: %s", string(buf))
+	}
+	if attempt != 2 {
+		t.Fatalf("expected 2 attempts, got %d", attempt)
 	}
 }
 


### PR DESCRIPTION
# Description

Introduce httpError type to capture HTTP status codes from non-JSON and empty-body responses, enabling automatic retry for transient HTTP errors (502, 503, 504, 429) that were previously only handled at the GraphQL error level.

Also fix empty-body detection to handle chunked transfer encoding by reading the body before checking length.

## Types of changes

What types of changes does your code introduce? Put an `x` in all the boxes that apply:
- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)

## Checklist:

Go over all the following points, and put an `x` in all the boxes that apply. If you're unsure about any of these, don't hesitate to ask. We're here to help!
- [x] My code follows the code style of this project.
- [ ] My change requires a change to the documentation.
- [ ] I have updated the documentation accordingly.
- [ ] I have updated the CHANGELOG file accordingly for the version that this merge modifies.
- [x] I have added tests to cover my changes.
- [x] All new and existing tests passed.
