### PR TITLE
Add AWS role chaining support

### DIFF
--- a/pkg/polaris/aws/cloud_account_cft.go
+++ b/pkg/polaris/aws/cloud_account_cft.go
@@ -51,6 +51,9 @@ func (a API) AddAccountWithCFT(ctx context.Context, account AccountFunc, feature
 	if len(features) == 0 {
 		return uuid.Nil, errors.New("no features specified")
 	}
+	if err := core.ValidateRoleChaining(features); err != nil {
+		return uuid.Nil, err
+	}
 
 	config, err := account(ctx)
 	if err != nil {

--- a/pkg/polaris/aws/cloud_account_iam.go
+++ b/pkg/polaris/aws/cloud_account_iam.go
@@ -47,6 +47,9 @@ func (a API) AddAccountWithIAM(ctx context.Context, account AccountFunc, feature
 	if account == nil {
 		return uuid.Nil, errors.New("account is not allowed to be nil")
 	}
+	if err := core.ValidateRoleChaining(features); err != nil {
+		return uuid.Nil, err
+	}
 	config, err := account(ctx)
 	if err != nil {
 		return uuid.Nil, fmt.Errorf("failed to lookup account: %s", err)
@@ -174,6 +177,10 @@ const (
 func (a API) Artifacts(ctx context.Context, cloud string, features []core.Feature) ([]string, []string, error) {
 	a.log.Print(log.Trace)
 
+	if err := core.ValidateRoleChaining(features); err != nil {
+		return nil, nil, err
+	}
+
 	c, err := aws.ParseCloud(cloud)
 	if err != nil {
 		return nil, nil, fmt.Errorf("failed to parse cloud: %s", err)
@@ -242,8 +249,9 @@ func (a API) AccountArtifacts(ctx context.Context, cloudAccountID uuid.UUID) (ma
 }
 
 // AddAccountArtifacts adds the specified artifacts, instance profiles and
-// roles, to the cloud account.
-func (a API) AddAccountArtifacts(ctx context.Context, cloudAccountID uuid.UUID, features []core.Feature, instanceProfiles map[string]string, roles map[string]string) (uuid.UUID, error) {
+// roles, to the cloud account. Pass uuid.Nil for roleChainingAccountID when
+// role chaining is not used.
+func (a API) AddAccountArtifacts(ctx context.Context, cloudAccountID uuid.UUID, features []core.Feature, instanceProfiles map[string]string, roles map[string]string, roleChainingAccountID uuid.UUID) (uuid.UUID, error) {
 	a.log.Print(log.Trace)
 
 	account, err := a.AccountByID(ctx, cloudAccountID)
@@ -284,7 +292,7 @@ func (a API) AddAccountArtifacts(ctx context.Context, cloudAccountID uuid.UUID, 
 			NativeID:  account.NativeID,
 			Features:  core.FeatureNames(features),
 			Artifacts: externalArtifacts,
-		}})
+		}}, roleChainingAccountID)
 		if err != nil {
 			return uuid.Nil, fmt.Errorf("failed to register feature artifacts: %s", err)
 		}
@@ -318,9 +326,10 @@ type TrustPolicyMap map[string]string
 // features. If the external ID is empty, RSC will generate an external ID.
 // The same endpoint is used both for reading and writing the trust policy,
 // a side effect of this is that the first call always set the trust policy.
+// Pass uuid.Nil for roleChainingAccountID when role chaining is not used.
 // Once the trust policy has been set, it cannot be changed.
 // If the account cannot be found, graphql.ErrNotFound is returned.
-func (a API) TrustPolicies(ctx context.Context, cloud aws.Cloud, cloudAccountID uuid.UUID, features []core.Feature, externalID string) (TrustPolicyMap, error) {
+func (a API) TrustPolicies(ctx context.Context, cloud aws.Cloud, cloudAccountID uuid.UUID, features []core.Feature, externalID string, roleChainingAccountID uuid.UUID) (TrustPolicyMap, error) {
 	a.log.Print(log.Trace)
 
 	// We need to look up the account to obtain the AWS native account ID.
@@ -333,7 +342,7 @@ func (a API) TrustPolicies(ctx context.Context, cloud aws.Cloud, cloudAccountID 
 	policies, err := aws.Wrap(a.client).TrustPolicy(ctx, cloud, features, []aws.TrustPolicyAccount{{
 		ID:         account.NativeID,
 		ExternalID: externalID,
-	}})
+	}}, roleChainingAccountID)
 	if err != nil {
 		return nil, fmt.Errorf("failed to get trust policies: %s", err)
 	}

--- a/pkg/polaris/aws/cloud_account_iam.go
+++ b/pkg/polaris/aws/cloud_account_iam.go
@@ -248,19 +248,28 @@ func (a API) AccountArtifacts(ctx context.Context, cloudAccountID uuid.UUID) (ma
 	return instanceProfiles, roles, nil
 }
 
+// AddAccountArtifactsParams holds the parameters for an AddAccountArtifacts
+// operation. RoleChainingAccountID is optional.
+type AddAccountArtifactsParams struct {
+	CloudAccountID        uuid.UUID
+	Features              []core.Feature
+	InstanceProfiles      map[string]string
+	Roles                 map[string]string
+	RoleChainingAccountID uuid.UUID
+}
+
 // AddAccountArtifacts adds the specified artifacts, instance profiles and
-// roles, to the cloud account. Pass uuid.Nil for roleChainingAccountID when
-// role chaining is not used.
-func (a API) AddAccountArtifacts(ctx context.Context, cloudAccountID uuid.UUID, features []core.Feature, instanceProfiles map[string]string, roles map[string]string, roleChainingAccountID uuid.UUID) (uuid.UUID, error) {
+// roles, to the cloud account.
+func (a API) AddAccountArtifacts(ctx context.Context, params AddAccountArtifactsParams) (uuid.UUID, error) {
 	a.log.Print(log.Trace)
 
-	account, err := a.AccountByID(ctx, cloudAccountID)
+	account, err := a.AccountByID(ctx, params.CloudAccountID)
 	if err != nil {
 		return uuid.Nil, err
 	}
 
-	externalArtifacts := make([]aws.ExternalArtifact, 0, len(instanceProfiles)+len(roles))
-	for key, value := range instanceProfiles {
+	externalArtifacts := make([]aws.ExternalArtifact, 0, len(params.InstanceProfiles)+len(params.Roles))
+	for key, value := range params.InstanceProfiles {
 		if !strings.HasSuffix(key, instanceProfileSuffix) {
 			key = key + instanceProfileSuffix
 		}
@@ -269,7 +278,7 @@ func (a API) AddAccountArtifacts(ctx context.Context, cloudAccountID uuid.UUID, 
 			ExternalArtifactValue: value,
 		})
 	}
-	for key, value := range roles {
+	for key, value := range params.Roles {
 		if !strings.HasSuffix(key, roleArnSuffix) {
 			key = key + roleArnSuffix
 		}
@@ -288,11 +297,15 @@ func (a API) AddAccountArtifacts(ctx context.Context, cloudAccountID uuid.UUID, 
 	now := time.Now()
 	var mappings []aws.NativeIDToRSCIDMapping
 	for {
-		mappings, err = aws.Wrap(a.client).RegisterFeatureArtifacts(ctx, aws.Cloud(account.Cloud), []aws.AccountFeatureArtifact{{
-			NativeID:  account.NativeID,
-			Features:  core.FeatureNames(features),
-			Artifacts: externalArtifacts,
-		}}, roleChainingAccountID)
+		mappings, err = aws.Wrap(a.client).RegisterFeatureArtifacts(ctx, aws.RegisterFeatureArtifactsParams{
+			Cloud: aws.Cloud(account.Cloud),
+			Artifacts: []aws.AccountFeatureArtifact{{
+				NativeID:  account.NativeID,
+				Features:  core.FeatureNames(params.Features),
+				Artifacts: externalArtifacts,
+			}},
+			RoleChainingAccountID: params.RoleChainingAccountID,
+		})
 		if err != nil {
 			return uuid.Nil, fmt.Errorf("failed to register feature artifacts: %s", err)
 		}
@@ -322,27 +335,41 @@ func (a API) AddAccountArtifacts(ctx context.Context, cloudAccountID uuid.UUID, 
 // TrustPolicyMap maps the role key to the trust policy.
 type TrustPolicyMap map[string]string
 
+// TrustPoliciesParams holds the parameters for a TrustPolicies operation.
+// RoleChainingAccountID is optional.
+type TrustPoliciesParams struct {
+	Cloud                 aws.Cloud
+	CloudAccountID        uuid.UUID
+	Features              []core.Feature
+	ExternalID            string
+	RoleChainingAccountID uuid.UUID
+}
+
 // TrustPolicies returns the trust policies required by RSC for the specified
 // features. If the external ID is empty, RSC will generate an external ID.
 // The same endpoint is used both for reading and writing the trust policy,
 // a side effect of this is that the first call always set the trust policy.
-// Pass uuid.Nil for roleChainingAccountID when role chaining is not used.
 // Once the trust policy has been set, it cannot be changed.
 // If the account cannot be found, graphql.ErrNotFound is returned.
-func (a API) TrustPolicies(ctx context.Context, cloud aws.Cloud, cloudAccountID uuid.UUID, features []core.Feature, externalID string, roleChainingAccountID uuid.UUID) (TrustPolicyMap, error) {
+func (a API) TrustPolicies(ctx context.Context, params TrustPoliciesParams) (TrustPolicyMap, error) {
 	a.log.Print(log.Trace)
 
 	// We need to look up the account to obtain the AWS native account ID.
 	// The call returns graphql.NotFound if the cloud account isn't found.
-	account, err := a.AccountByID(ctx, cloudAccountID)
+	account, err := a.AccountByID(ctx, params.CloudAccountID)
 	if err != nil {
 		return nil, err
 	}
 
-	policies, err := aws.Wrap(a.client).TrustPolicy(ctx, cloud, features, []aws.TrustPolicyAccount{{
-		ID:         account.NativeID,
-		ExternalID: externalID,
-	}}, roleChainingAccountID)
+	policies, err := aws.Wrap(a.client).TrustPolicy(ctx, aws.TrustPolicyParams{
+		Cloud:    params.Cloud,
+		Features: params.Features,
+		TrustPolicyAccounts: []aws.TrustPolicyAccount{{
+			ID:         account.NativeID,
+			ExternalID: params.ExternalID,
+		}},
+		RoleChainingAccountID: params.RoleChainingAccountID,
+	})
 	if err != nil {
 		return nil, fmt.Errorf("failed to get trust policies: %s", err)
 	}

--- a/pkg/polaris/aws/permissions.go
+++ b/pkg/polaris/aws/permissions.go
@@ -60,6 +60,10 @@ func (policy ManagedPolicy) lessThan(other ManagedPolicy) bool {
 func (a API) Permissions(ctx context.Context, cloud string, features []core.Feature, ec2RecoveryRolePath string) ([]CustomerManagedPolicy, []ManagedPolicy, error) {
 	a.log.Print(log.Trace)
 
+	if err := core.ValidateRoleChaining(features); err != nil {
+		return nil, nil, err
+	}
+
 	c, err := aws.ParseCloud(cloud)
 	if err != nil {
 		return nil, nil, fmt.Errorf("failed to parse cloud: %s", err)

--- a/pkg/polaris/graphql/aws/cloud_no_cft.go
+++ b/pkg/polaris/graphql/aws/cloud_no_cft.go
@@ -95,9 +95,18 @@ type TrustPolicyArtifact struct {
 	ErrorMessage        string `json:"errorMessage"`
 }
 
+// TrustPolicyParams holds the parameters for a TrustPolicy operation.
+// RoleChainingAccountID is optional.
+type TrustPolicyParams struct {
+	Cloud                 Cloud
+	Features              []core.Feature
+	TrustPolicyAccounts   []TrustPolicyAccount
+	RoleChainingAccountID uuid.UUID
+}
+
 // TrustPolicy returns the trust policy for the specified account and external
-// id. Pass uuid.Nil for roleChainingAccountID when role chaining is not used.
-func (a API) TrustPolicy(ctx context.Context, cloud Cloud, features []core.Feature, trustPolicyAccounts []TrustPolicyAccount, roleChainingAccountID uuid.UUID) ([]TrustPolicy, error) {
+// id.
+func (a API) TrustPolicy(ctx context.Context, params TrustPolicyParams) ([]TrustPolicy, error) {
 	a.log.Print(log.Trace)
 
 	query := awsTrustPolicyQuery
@@ -106,7 +115,7 @@ func (a API) TrustPolicy(ctx context.Context, cloud Cloud, features []core.Featu
 		Features              []string             `json:"features"`
 		NativeAccounts        []TrustPolicyAccount `json:"awsNativeAccounts"`
 		RoleChainingAccountID uuid.UUID            `json:"roleChainingAccountId,omitzero"`
-	}{Cloud: cloud, Features: core.FeatureNames(features), NativeAccounts: trustPolicyAccounts, RoleChainingAccountID: roleChainingAccountID})
+	}{Cloud: params.Cloud, Features: core.FeatureNames(params.Features), NativeAccounts: params.TrustPolicyAccounts, RoleChainingAccountID: params.RoleChainingAccountID})
 	if err != nil {
 		return nil, graphql.RequestError(query, err)
 	}
@@ -147,10 +156,17 @@ type NativeIDToRSCIDMapping struct {
 	Message        string `json:"Message"`
 }
 
+// RegisterFeatureArtifactsParams holds the parameters for a
+// RegisterFeatureArtifacts operation. RoleChainingAccountID is optional.
+type RegisterFeatureArtifactsParams struct {
+	Cloud                 Cloud
+	Artifacts             []AccountFeatureArtifact
+	RoleChainingAccountID uuid.UUID
+}
+
 // RegisterFeatureArtifacts registers the specified artifacts with the cloud
-// account identified by the native ID. Pass uuid.Nil for roleChainingAccountID
-// when role chaining is not used.
-func (a API) RegisterFeatureArtifacts(ctx context.Context, cloud Cloud, artifacts []AccountFeatureArtifact, roleChainingAccountID uuid.UUID) ([]NativeIDToRSCIDMapping, error) {
+// account identified by the native ID.
+func (a API) RegisterFeatureArtifacts(ctx context.Context, params RegisterFeatureArtifactsParams) ([]NativeIDToRSCIDMapping, error) {
 	a.log.Print(log.Trace)
 
 	query := registerAwsFeatureArtifactsQuery
@@ -158,7 +174,7 @@ func (a API) RegisterFeatureArtifacts(ctx context.Context, cloud Cloud, artifact
 		Cloud                 Cloud                    `json:"cloudType"`
 		Artifacts             []AccountFeatureArtifact `json:"awsArtifacts"`
 		RoleChainingAccountID uuid.UUID                `json:"roleChainingAccountId,omitzero"`
-	}{Cloud: cloud, Artifacts: artifacts, RoleChainingAccountID: roleChainingAccountID})
+	}{Cloud: params.Cloud, Artifacts: params.Artifacts, RoleChainingAccountID: params.RoleChainingAccountID})
 	if err != nil {
 		return nil, graphql.RequestError(query, err)
 	}

--- a/pkg/polaris/graphql/aws/cloud_no_cft.go
+++ b/pkg/polaris/graphql/aws/cloud_no_cft.go
@@ -96,16 +96,17 @@ type TrustPolicyArtifact struct {
 }
 
 // TrustPolicy returns the trust policy for the specified account and external
-// id.
-func (a API) TrustPolicy(ctx context.Context, cloud Cloud, features []core.Feature, trustPolicyAccounts []TrustPolicyAccount) ([]TrustPolicy, error) {
+// id. Pass uuid.Nil for roleChainingAccountID when role chaining is not used.
+func (a API) TrustPolicy(ctx context.Context, cloud Cloud, features []core.Feature, trustPolicyAccounts []TrustPolicyAccount, roleChainingAccountID uuid.UUID) ([]TrustPolicy, error) {
 	a.log.Print(log.Trace)
 
 	query := awsTrustPolicyQuery
 	buf, err := a.GQL.Request(ctx, query, struct {
-		Cloud          Cloud                `json:"cloudType"`
-		Features       []string             `json:"features"`
-		NativeAccounts []TrustPolicyAccount `json:"awsNativeAccounts"`
-	}{Cloud: cloud, Features: core.FeatureNames(features), NativeAccounts: trustPolicyAccounts})
+		Cloud                 Cloud                `json:"cloudType"`
+		Features              []string             `json:"features"`
+		NativeAccounts        []TrustPolicyAccount `json:"awsNativeAccounts"`
+		RoleChainingAccountID uuid.UUID            `json:"roleChainingAccountId,omitzero"`
+	}{Cloud: cloud, Features: core.FeatureNames(features), NativeAccounts: trustPolicyAccounts, RoleChainingAccountID: roleChainingAccountID})
 	if err != nil {
 		return nil, graphql.RequestError(query, err)
 	}
@@ -147,15 +148,17 @@ type NativeIDToRSCIDMapping struct {
 }
 
 // RegisterFeatureArtifacts registers the specified artifacts with the cloud
-// account identified by the native ID.
-func (a API) RegisterFeatureArtifacts(ctx context.Context, cloud Cloud, artifacts []AccountFeatureArtifact) ([]NativeIDToRSCIDMapping, error) {
+// account identified by the native ID. Pass uuid.Nil for roleChainingAccountID
+// when role chaining is not used.
+func (a API) RegisterFeatureArtifacts(ctx context.Context, cloud Cloud, artifacts []AccountFeatureArtifact, roleChainingAccountID uuid.UUID) ([]NativeIDToRSCIDMapping, error) {
 	a.log.Print(log.Trace)
 
 	query := registerAwsFeatureArtifactsQuery
 	buf, err := a.GQL.Request(ctx, query, struct {
-		Cloud     Cloud                    `json:"cloudType"`
-		Artifacts []AccountFeatureArtifact `json:"awsArtifacts"`
-	}{Cloud: cloud, Artifacts: artifacts})
+		Cloud                 Cloud                    `json:"cloudType"`
+		Artifacts             []AccountFeatureArtifact `json:"awsArtifacts"`
+		RoleChainingAccountID uuid.UUID                `json:"roleChainingAccountId,omitzero"`
+	}{Cloud: cloud, Artifacts: artifacts, RoleChainingAccountID: roleChainingAccountID})
 	if err != nil {
 		return nil, graphql.RequestError(query, err)
 	}

--- a/pkg/polaris/graphql/aws/queries.go
+++ b/pkg/polaris/graphql/aws/queries.go
@@ -207,8 +207,8 @@ var awsNativeAccountsQuery = `query SdkGolangAwsNativeAccounts(
 }`
 
 // awsTrustPolicy GraphQL query
-var awsTrustPolicyQuery = `query SdkGolangAwsTrustPolicy($cloudType: AwsCloudType!, $features: [CloudAccountFeature!]!, $awsNativeAccounts: [AwsNativeAccountInput!]!) {
-    result: awsTrustPolicy(input: {cloudType: $cloudType, features: $features, awsNativeAccounts: $awsNativeAccounts}) {
+var awsTrustPolicyQuery = `query SdkGolangAwsTrustPolicy($cloudType: AwsCloudType!, $features: [CloudAccountFeature!]!, $awsNativeAccounts: [AwsNativeAccountInput!]!, $roleChainingAccountId: UUID) {
+    result: awsTrustPolicy(input: {cloudType: $cloudType, features: $features, awsNativeAccounts: $awsNativeAccounts, roleChainingAccountId: $roleChainingAccountId}) {
         result {
             artifacts {
                 externalArtifactKey
@@ -306,8 +306,8 @@ var prepareFeatureUpdateForAwsCloudAccountQuery = `mutation SdkGolangPrepareFeat
 }`
 
 // registerAwsFeatureArtifacts GraphQL query
-var registerAwsFeatureArtifactsQuery = `mutation SdkGolangRegisterAwsFeatureArtifacts($cloudType: AwsCloudType, $awsArtifacts: [AwsAccountFeatureArtifact!]!) {
-    result: registerAwsFeatureArtifacts(input: {cloudType: $cloudType, awsArtifacts: $awsArtifacts}) {
+var registerAwsFeatureArtifactsQuery = `mutation SdkGolangRegisterAwsFeatureArtifacts($cloudType: AwsCloudType, $awsArtifacts: [AwsAccountFeatureArtifact!]!, $roleChainingAccountId: UUID) {
+    result: registerAwsFeatureArtifacts(input: {cloudType: $cloudType, awsArtifacts: $awsArtifacts, roleChainingAccountId: $roleChainingAccountId}) {
         allAwsNativeIdtoRscIdMappings {
             awsCloudAccountId
             awsNativeId

--- a/pkg/polaris/graphql/aws/queries/aws_trust_policy.graphql
+++ b/pkg/polaris/graphql/aws/queries/aws_trust_policy.graphql
@@ -1,5 +1,5 @@
-query RubrikPolarisSDKRequest($cloudType: AwsCloudType!, $features: [CloudAccountFeature!]!, $awsNativeAccounts: [AwsNativeAccountInput!]!) {
-    result: awsTrustPolicy(input: {cloudType: $cloudType, features: $features, awsNativeAccounts: $awsNativeAccounts}) {
+query RubrikPolarisSDKRequest($cloudType: AwsCloudType!, $features: [CloudAccountFeature!]!, $awsNativeAccounts: [AwsNativeAccountInput!]!, $roleChainingAccountId: UUID) {
+    result: awsTrustPolicy(input: {cloudType: $cloudType, features: $features, awsNativeAccounts: $awsNativeAccounts, roleChainingAccountId: $roleChainingAccountId}) {
         result {
             artifacts {
                 externalArtifactKey

--- a/pkg/polaris/graphql/aws/queries/register_aws_feature_artifacts.graphql
+++ b/pkg/polaris/graphql/aws/queries/register_aws_feature_artifacts.graphql
@@ -1,5 +1,5 @@
-mutation RubrikPolarisSDKRequest($cloudType: AwsCloudType, $awsArtifacts: [AwsAccountFeatureArtifact!]!) {
-    result: registerAwsFeatureArtifacts(input: {cloudType: $cloudType, awsArtifacts: $awsArtifacts}) {
+mutation RubrikPolarisSDKRequest($cloudType: AwsCloudType, $awsArtifacts: [AwsAccountFeatureArtifact!]!, $roleChainingAccountId: UUID) {
+    result: registerAwsFeatureArtifacts(input: {cloudType: $cloudType, awsArtifacts: $awsArtifacts, roleChainingAccountId: $roleChainingAccountId}) {
         allAwsNativeIdtoRscIdMappings {
             awsCloudAccountId
             awsNativeId

--- a/pkg/polaris/graphql/core/core.go
+++ b/pkg/polaris/graphql/core/core.go
@@ -35,7 +35,6 @@ import (
 	"time"
 
 	"github.com/google/uuid"
-
 	"github.com/rubrikinc/rubrik-polaris-sdk-for-go/pkg/polaris/graphql"
 	"github.com/rubrikinc/rubrik-polaris-sdk-for-go/pkg/polaris/graphql/hierarchy"
 	"github.com/rubrikinc/rubrik-polaris-sdk-for-go/pkg/polaris/graphql/sla"
@@ -274,6 +273,19 @@ func LookupFeature(features []Feature, feature Feature) (Feature, bool) {
 	}
 
 	return Feature{}, false
+}
+
+// ValidateRoleChaining returns an error if ROLE_CHAINING is combined with
+// other features. The ROLE_CHAINING feature is mutually exclusive with all
+// other features.
+func ValidateRoleChaining(features []Feature) error {
+	if len(features) < 2 {
+		return nil
+	}
+	if _, ok := LookupFeature(features, FeatureRoleChaining); ok {
+		return errors.New("ROLE_CHAINING is mutually exclusive with all other features")
+	}
+	return nil
 }
 
 // FilterFeaturesOnPermissionGroups verifies that all features either have no


### PR DESCRIPTION
# Description

Add AWS role chaining support to the Go SDK. This adds `ValidateRoleChaining` to enforce that `ROLE_CHAINING` is mutually exclusive with all other features, and adds `roleChainingAccountID uuid.UUID` to the trust policy and artifact registration paths so that accounts linked to a role chaining account can be onboarded correctly.

## Motivation and Context

AWS role chaining introduces a mediator account between RSC and customer AWS accounts, allowing customers to revoke Rubrik's access to all accounts by modifying a single trust policy. The SDK needs to pass the `roleChainingAccountId` to the `awsTrustPolicy` and `registerAwsFeatureArtifacts` GraphQL endpoints to support this workflow.

## How Has This Been Tested?

Manually tested against a dev RSC instance by onboarding a role chaining account and a mapped account using the Terraform provider and the `aws_iam_account` example module. All unit tests pass.

## Types of changes

- [ ] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [x] Breaking change (fix or feature that would cause existing functionality to change)

## Checklist:

- [x] My code follows the code style of this project.
- [ ] My change requires a change to the documentation.
- [ ] I have updated the documentation accordingly.
- [ ] I have updated the CHANGELOG file accordingly for the version that this merge modifies.
- [ ] I have added tests to cover my changes.
- [x] All new and existing tests passed.
