### PR TITLE
Use omitzero for RetentionDuration fields in SLA object configs

### DIFF
--- a/pkg/polaris/graphql/sla/sla_domain.go
+++ b/pkg/polaris/graphql/sla/sla_domain.go
@@ -150,24 +150,24 @@ type VMwareVMConfig struct {
 // SapHanaConfig represents the configuration specific for a SAP HANA database
 // object.
 type SapHanaConfig struct {
-	IncrementalFrequency  RetentionDuration             `json:"incrementalFrequency,omitempty"`
-	LogRetention          RetentionDuration             `json:"logRetention,omitempty"`
-	DifferentialFrequency RetentionDuration             `json:"differentialFrequency,omitempty"`
+	IncrementalFrequency  RetentionDuration             `json:"incrementalFrequency,omitzero"`
+	LogRetention          RetentionDuration             `json:"logRetention,omitzero"`
+	DifferentialFrequency RetentionDuration             `json:"differentialFrequency,omitzero"`
 	StorageSnapshotConfig *SapHanaStorageSnapshotConfig `json:"storageSnapshotConfig,omitempty"`
 }
 
 // SapHanaStorageSnapshotConfig represents the storage snapshot configuration
 // for SAP HANA.
 type SapHanaStorageSnapshotConfig struct {
-	Frequency RetentionDuration `json:"frequency,omitempty"`
-	Retention RetentionDuration `json:"retention,omitempty"`
+	Frequency RetentionDuration `json:"frequency,omitzero"`
+	Retention RetentionDuration `json:"retention,omitzero"`
 }
 
 // DB2Config represents the configuration specific for a Db2 database object.
 type DB2Config struct {
-	IncrementalFrequency  RetentionDuration    `json:"incrementalFrequency,omitempty"`
-	LogRetention          RetentionDuration    `json:"logRetention,omitempty"`
-	DifferentialFrequency RetentionDuration    `json:"differentialFrequency,omitempty"`
+	IncrementalFrequency  RetentionDuration    `json:"incrementalFrequency,omitzero"`
+	LogRetention          RetentionDuration    `json:"logRetention,omitzero"`
+	DifferentialFrequency RetentionDuration    `json:"differentialFrequency,omitzero"`
 	LogArchivalMethod     Db2LogArchivalMethod `json:"logArchivalMethod,omitempty"`
 }
 
@@ -184,41 +184,41 @@ const (
 // MssqlConfig represents the configuration specific for a SQL Server database
 // object.
 type MssqlConfig struct {
-	Frequency    RetentionDuration `json:"frequency,omitempty"`
-	LogRetention RetentionDuration `json:"logRetention,omitempty"`
+	Frequency    RetentionDuration `json:"frequency,omitzero"`
+	LogRetention RetentionDuration `json:"logRetention,omitzero"`
 }
 
 // OracleConfig represents the configuration specific for an Oracle database
 // object.
 type OracleConfig struct {
-	Frequency        RetentionDuration `json:"frequency,omitempty"`
-	LogRetention     RetentionDuration `json:"logRetention,omitempty"`
-	HostLogRetention RetentionDuration `json:"hostLogRetention,omitempty"`
+	Frequency        RetentionDuration `json:"frequency,omitzero"`
+	LogRetention     RetentionDuration `json:"logRetention,omitzero"`
+	HostLogRetention RetentionDuration `json:"hostLogRetention,omitzero"`
 }
 
 // MongoConfig represents the configuration specific for a MongoDB database
 // object.
 type MongoConfig struct {
-	LogFrequency RetentionDuration `json:"logFrequency,omitempty"`
-	LogRetention RetentionDuration `json:"logRetention,omitempty"`
+	LogFrequency RetentionDuration `json:"logFrequency,omitzero"`
+	LogRetention RetentionDuration `json:"logRetention,omitzero"`
 }
 
 // ManagedVolumeSlaConfig represents the configuration specific for a Managed
 // Volume object.
 type ManagedVolumeSlaConfig struct {
-	LogRetention RetentionDuration `json:"logRetention,omitempty"`
+	LogRetention RetentionDuration `json:"logRetention,omitzero"`
 }
 
 // PostgresDbClusterSlaConfig represents the configuration specific for a
 // Postgres DB Cluster object.
 type PostgresDbClusterSlaConfig struct {
-	LogRetention RetentionDuration `json:"logRetention,omitempty"`
+	LogRetention RetentionDuration `json:"logRetention,omitzero"`
 }
 
 // MysqldbSlaConfig represents the configuration specific for a MySQL object.
 type MysqldbSlaConfig struct {
-	LogFrequency RetentionDuration `json:"logFrequency,omitempty"`
-	LogRetention RetentionDuration `json:"logRetention,omitempty"`
+	LogFrequency RetentionDuration `json:"logFrequency,omitzero"`
+	LogRetention RetentionDuration `json:"logRetention,omitzero"`
 }
 
 // NcdSlaConfig represents the configuration specific for a NAS Cloud Direct
@@ -236,16 +236,16 @@ type NcdSlaConfig struct {
 // InformixSlaConfig represents the configuration specific for an Informix
 // object.
 type InformixSlaConfig struct {
-	IncrementalFrequency RetentionDuration `json:"incrementalFrequency,omitempty"`
-	IncrementalRetention RetentionDuration `json:"incrementalRetention,omitempty"`
-	LogFrequency         RetentionDuration `json:"logFrequency,omitempty"`
-	LogRetention         RetentionDuration `json:"logRetention,omitempty"`
+	IncrementalFrequency RetentionDuration `json:"incrementalFrequency,omitzero"`
+	IncrementalRetention RetentionDuration `json:"incrementalRetention,omitzero"`
+	LogFrequency         RetentionDuration `json:"logFrequency,omitzero"`
+	LogRetention         RetentionDuration `json:"logRetention,omitzero"`
 }
 
 // GcpCloudSqlConfig represents the configuration specific for a GCP Cloud SQL
 // object.
 type GcpCloudSqlConfig struct {
-	LogRetention RetentionDuration `json:"logRetention,omitempty"`
+	LogRetention RetentionDuration `json:"logRetention,omitzero"`
 }
 
 // SnapshotSchedule holds the snapshot schedule for an RSC global SLA domain.

--- a/pkg/polaris/graphql/sla/sla_domain_test.go
+++ b/pkg/polaris/graphql/sla/sla_domain_test.go
@@ -1,0 +1,106 @@
+// Copyright 2026 Rubrik, Inc.
+//
+// Permission is hereby granted, free of charge, to any person obtaining a copy
+// of this software and associated documentation files (the "Software"), to
+// deal in the Software without restriction, including without limitation the
+// rights to use, copy, modify, merge, publish, distribute, sublicense, and/or
+// sell copies of the Software, and to permit persons to whom the Software is
+// furnished to do so, subject to the following conditions:
+//
+// The above copyright notice and this permission notice shall be included in
+// all copies or substantial portions of the Software.
+//
+// THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+// IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+// FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+// AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+// LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING
+// FROM, OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER
+// DEALINGS IN THE SOFTWARE.
+
+package sla
+
+import (
+	"encoding/json"
+	"strings"
+	"testing"
+)
+
+// TestObjectSpecificConfigsOmitZeroRetention verifies that object-specific
+// SLA config structs marshal zero-valued RetentionDuration fields as omitted,
+// not as {"duration":0,"unit":""}. The latter is rejected by the GraphQL
+// backend because "" is not a valid RetentionUnit enum.
+func TestObjectSpecificConfigsOmitZeroRetention(t *testing.T) {
+	tests := []struct {
+		name        string
+		value       any
+		mustHave    []string
+		mustNotHave []string
+	}{
+		{
+			name: "SapHanaConfig with only IncrementalFrequency",
+			value: SapHanaConfig{
+				IncrementalFrequency: RetentionDuration{Duration: 1, Unit: Days},
+			},
+			mustHave:    []string{`"incrementalFrequency"`},
+			mustNotHave: []string{`"logRetention"`, `"differentialFrequency"`, `"unit":""`},
+		},
+		{
+			name:        "SapHanaConfig empty",
+			value:       SapHanaConfig{},
+			mustNotHave: []string{`"incrementalFrequency"`, `"logRetention"`, `"differentialFrequency"`, `"unit":""`},
+		},
+		{
+			name: "DB2Config with only LogRetention",
+			value: DB2Config{
+				LogRetention: RetentionDuration{Duration: 7, Unit: Days},
+			},
+			mustHave:    []string{`"logRetention"`},
+			mustNotHave: []string{`"incrementalFrequency"`, `"differentialFrequency"`, `"unit":""`},
+		},
+		{
+			name: "InformixSlaConfig with only LogFrequency",
+			value: InformixSlaConfig{
+				LogFrequency: RetentionDuration{Duration: 1, Unit: Hours},
+			},
+			mustHave: []string{`"logFrequency"`},
+			mustNotHave: []string{
+				`"incrementalFrequency"`, `"incrementalRetention"`, `"logRetention"`, `"unit":""`,
+			},
+		},
+		{
+			name: "OracleConfig with only Frequency and LogRetention",
+			value: OracleConfig{
+				Frequency:    RetentionDuration{Duration: 1, Unit: Days},
+				LogRetention: RetentionDuration{Duration: 7, Unit: Days},
+			},
+			mustHave:    []string{`"frequency"`, `"logRetention"`},
+			mustNotHave: []string{`"hostLogRetention"`, `"unit":""`},
+		},
+		{
+			name:        "SapHanaStorageSnapshotConfig empty",
+			value:       SapHanaStorageSnapshotConfig{},
+			mustNotHave: []string{`"frequency"`, `"retention"`, `"unit":""`},
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			data, err := json.Marshal(tt.value)
+			if err != nil {
+				t.Fatalf("Marshal failed: %v", err)
+			}
+			s := string(data)
+			for _, want := range tt.mustHave {
+				if !strings.Contains(s, want) {
+					t.Errorf("expected JSON to contain %s, got %s", want, s)
+				}
+			}
+			for _, unwant := range tt.mustNotHave {
+				if strings.Contains(s, unwant) {
+					t.Errorf("expected JSON to not contain %s, got %s", unwant, s)
+				}
+			}
+		})
+	}
+}


### PR DESCRIPTION
# Description

Embedded RetentionDuration fields in object-specific SLA configs (SapHanaConfig, DB2Config, MssqlConfig, OracleConfig, MongoConfig, ManagedVolumeSlaConfig, PostgresDbClusterSlaConfig, MysqldbSlaConfig, InformixSlaConfig, GcpCloudSqlConfig and SapHanaStorageSnapshotConfig) were tagged with json omitempty. encoding/json does not omit zero-valued struct fields with omitempty, so unset fields were marshaled as {"duration":0,"unit":""} and the RSC GraphQL backend rejected the empty RetentionUnit enum value.

Replace omitempty with omitzero on these fields so unset values are properly dropped from the request. Add a unit test that pins the behavior for several representative configs.

## Related Issue

Raised from rubrikinc/terraform-provider-polaris#430

## How Has This Been Tested?

Manually

## Types of changes

What types of changes does your code introduce? Put an `x` in all the boxes that apply:
- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)

## Checklist:

Go over all the following points, and put an `x` in all the boxes that apply. If you're unsure about any of these, don't hesitate to ask. We're here to help!
- [x] My code follows the code style of this project.
- [x] My change requires a change to the documentation.
- [x] I have updated the documentation accordingly.
- [ ] I have updated the CHANGELOG file accordingly for the version that this merge modifies.
- [x] I have added tests to cover my changes.
- [x] All new and existing tests passed.
