### PR TITLE
Add RUBRIK_ environment variable aliases

### DIFF
--- a/internal/env/env.go
+++ b/internal/env/env.go
@@ -1,0 +1,36 @@
+// Copyright 2026 Rubrik, Inc.
+//
+// Permission is hereby granted, free of charge, to any person obtaining a copy
+// of this software and associated documentation files (the "Software"), to
+// deal in the Software without restriction, including without limitation the
+// rights to use, copy, modify, merge, publish, distribute, sublicense, and/or
+// sell copies of the Software, and to permit persons to whom the Software is
+// furnished to do so, subject to the following conditions:
+//
+// The above copyright notice and this permission notice shall be included in
+// all copies or substantial portions of the Software.
+//
+// THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+// IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+// FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+// AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+// LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING
+// FROM, OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER
+// DEALINGS IN THE SOFTWARE.
+
+// Package env provides helpers for reading environment variables.
+package env
+
+import (
+	"os"
+	"strings"
+)
+
+// Get returns the value of the environment variable named by key. If key is
+// not set, it falls back to the RUBRIK_POLARIS_ prefixed variant of the key.
+func Get(key string) string {
+	if val := os.Getenv(key); val != "" {
+		return val
+	}
+	return os.Getenv(strings.Replace(key, "RUBRIK_", "RUBRIK_POLARIS_", 1))
+}

--- a/pkg/polaris/config.go
+++ b/pkg/polaris/config.go
@@ -28,6 +28,8 @@ import (
 	"os"
 	"path/filepath"
 	"strings"
+
+	"github.com/rubrikinc/rubrik-polaris-sdk-for-go/internal/env"
 )
 
 const (
@@ -38,20 +40,20 @@ const (
 	DefaultServiceAccountFile = "~/.rubrik/polaris-service-account.json"
 
 	// UserAccount environment variables.
-	keyUserAccountCredentials = "RUBRIK_POLARIS_ACCOUNT_CREDENTIALS"
-	keyUserAccountFile        = "RUBRIK_POLARIS_ACCOUNT_FILE"
-	keyUserAccountName        = "RUBRIK_POLARIS_ACCOUNT_NAME"
-	keyUserAccountPassword    = "RUBRIK_POLARIS_ACCOUNT_PASSWORD"
-	keyUserAccountURL         = "RUBRIK_POLARIS_ACCOUNT_URL"
-	keyUserAccountUsername    = "RUBRIK_POLARIS_ACCOUNT_USERNAME"
+	keyUserAccountCredentials = "RUBRIK_ACCOUNT_CREDENTIALS"
+	keyUserAccountFile        = "RUBRIK_ACCOUNT_FILE"
+	keyUserAccountName        = "RUBRIK_ACCOUNT_NAME"
+	keyUserAccountPassword    = "RUBRIK_ACCOUNT_PASSWORD"
+	keyUserAccountURL         = "RUBRIK_ACCOUNT_URL"
+	keyUserAccountUsername    = "RUBRIK_ACCOUNT_USERNAME"
 
 	// ServiceAccount environment variables.
-	keyServiceAccountAccessTokenURI = "RUBRIK_POLARIS_SERVICEACCOUNT_ACCESSTOKENURI"
-	keyServiceAccountClientID       = "RUBRIK_POLARIS_SERVICEACCOUNT_CLIENTID"
-	keyServiceAccountClientSecret   = "RUBRIK_POLARIS_SERVICEACCOUNT_CLIENTSECRET"
-	keyServiceAccountCredentials    = "RUBRIK_POLARIS_SERVICEACCOUNT_CREDENTIALS"
-	keyServiceAccountFile           = "RUBRIK_POLARIS_SERVICEACCOUNT_FILE"
-	keyServiceAccountName           = "RUBRIK_POLARIS_SERVICEACCOUNT_NAME"
+	keyServiceAccountAccessTokenURI = "RUBRIK_SERVICEACCOUNT_ACCESSTOKENURI"
+	keyServiceAccountClientID       = "RUBRIK_SERVICEACCOUNT_CLIENTID"
+	keyServiceAccountClientSecret   = "RUBRIK_SERVICEACCOUNT_CLIENTSECRET"
+	keyServiceAccountCredentials    = "RUBRIK_SERVICEACCOUNT_CREDENTIALS"
+	keyServiceAccountFile           = "RUBRIK_SERVICEACCOUNT_FILE"
+	keyServiceAccountName           = "RUBRIK_SERVICEACCOUNT_NAME"
 )
 
 var (
@@ -212,7 +214,7 @@ func (a *UserAccount) cacheSuffixMaterial() string {
 //
 // If allowEnvOverride is true environment variables can be used to override
 // user information in the file. See UserAccountFromEnv for details.
-// In addition, the environment variable RUBRIK_POLARIS_ACCOUNT_FILE can be used
+// In addition, the environment variable RUBRIK_ACCOUNT_FILE can be used
 // to override the file that the user information is read from.
 //
 // Note that RSC user accounts with MFA enabled cannot be used.
@@ -222,7 +224,7 @@ func DefaultUserAccount(name string, allowEnvOverride bool) (*UserAccount, error
 
 // UserAccountFromEnv returns a new UserAccount from the current environment.
 // The account can be stored as a single JSON encoded environment variable
-// (RUBRIK_POLARIS_ACCOUNT_CREDENTIALS) or as multiple plain text environment
+// (RUBRIK_ACCOUNT_CREDENTIALS) or as multiple plain text environment
 // variables (e.g. name, username, etc.). When using a single environment
 // variable, the JSON content should have the following structure:
 //
@@ -249,11 +251,11 @@ func DefaultUserAccount(name string, allowEnvOverride bool) (*UserAccount, error
 //	}
 //
 // The later format is used to hold multiple accounts. The environment variable
-// RUBRIK_POLARIS_ACCOUNT_NAME specifies which account to use.
+// RUBRIK_ACCOUNT_NAME specifies which account to use.
 //
 // When using multiple environment variables, they must have the same name as
 // the public UserAccount fields but be all upper case and prepended with
-// RUBRIK_POLARIS_ACCOUNT, e.g. RUBRIK_POLARIS_ACCOUNT_NAME.
+// RUBRIK_ACCOUNT, e.g. RUBRIK_ACCOUNT_NAME.
 //
 // Note that RSC user accounts with MFA enabled cannot be used.
 func UserAccountFromEnv() (*UserAccount, error) {
@@ -303,7 +305,7 @@ func UserAccountFromEnv() (*UserAccount, error) {
 //
 // If allowEnvOverride is true, environment variables can be used to override
 // user information in the file. See UserAccountFromEnv for details.
-// In addition, the environment variable RUBRIK_POLARIS_ACCOUNT_FILE can be used
+// In addition, the environment variable RUBRIK_ACCOUNT_FILE can be used
 // to override the file that the user information is read from.
 //
 // Note that RSC user accounts with MFA enabled cannot be used.
@@ -315,7 +317,7 @@ func UserAccountFromFile(file, name string, allowEnvOverride bool) (*UserAccount
 			name = envAccount.Name
 		}
 
-		if val := os.Getenv(keyUserAccountFile); val != "" {
+		if val := env.Get(keyUserAccountFile); val != "" {
 			file = val
 		}
 	}
@@ -359,24 +361,24 @@ func lookupUserAccount(name string, accounts map[string]UserAccount) UserAccount
 // environment.
 func userAccountFromEnv(name string) UserAccount {
 	var accounts map[string]UserAccount
-	if val := os.Getenv(keyUserAccountCredentials); val != "" {
+	if val := env.Get(keyUserAccountCredentials); val != "" {
 		var credAccounts map[string]UserAccount
 		if err := json.Unmarshal([]byte(val), &credAccounts); err == nil {
 			accounts = credAccounts
 		}
 	}
-	if val := os.Getenv(keyUserAccountName); val != "" {
+	if val := env.Get(keyUserAccountName); val != "" {
 		name = val
 	}
 
 	account := lookupUserAccount(name, accounts)
-	if val := os.Getenv(keyUserAccountUsername); val != "" {
+	if val := env.Get(keyUserAccountUsername); val != "" {
 		account.Username = val
 	}
-	if val := os.Getenv(keyUserAccountPassword); val != "" {
+	if val := env.Get(keyUserAccountPassword); val != "" {
 		account.Password = val
 	}
-	if val := os.Getenv(keyUserAccountURL); val != "" {
+	if val := env.Get(keyUserAccountURL); val != "" {
 		account.URL = val
 	}
 
@@ -521,7 +523,7 @@ func (a *ServiceAccount) cacheSuffixMaterial() string {
 //
 // If allowEnvOverride is true, environment variables can be used to override
 // account information in the file. See ServiceAccountFromEnv for details. In
-// addition, the environment variable RUBRIK_POLARIS_SERVICEACCOUNT_FILE can be
+// addition, the environment variable RUBRIK_SERVICEACCOUNT_FILE can be
 // used to override the file that the service account is read from.
 func DefaultServiceAccount(allowEnvOverride bool) (*ServiceAccount, error) {
 	return ServiceAccountFromFile(DefaultServiceAccountFile, allowEnvOverride)
@@ -529,12 +531,12 @@ func DefaultServiceAccount(allowEnvOverride bool) (*ServiceAccount, error) {
 
 // ServiceAccountFromEnv returns a new ServiceAccount from the current
 // environment. The account can be stored as a single environment variable
-// (RUBRIK_POLARIS_SERVICEACCOUNT_CREDENTIALS) or as multiple environment
+// (RUBRIK_SERVICEACCOUNT_CREDENTIALS) or as multiple environment
 // variables. When using a single environment variable, the content should be
 // the RSC service account file downloaded from RSC when creating the service
 // account. When using multiple environment variables, they must have the same
 // name as the public ServiceAccount fields but be all upper case and prepended
-// with RUBRIK_POLARIS_SERVICEACCOUNT, e.g. RUBRIK_POLARIS_SERVICEACCOUNT_NAME.
+// with RUBRIK_SERVICEACCOUNT, e.g. RUBRIK_SERVICEACCOUNT_NAME.
 func ServiceAccountFromEnv() (*ServiceAccount, error) {
 	account := serviceAccountFromEnv()
 	account.envOverride = true
@@ -555,11 +557,11 @@ func ServiceAccountFromEnv() (*ServiceAccount, error) {
 //
 // If allowEnvOverride is true environment variables can be used to override
 // account information in the file. See ServiceAccountFromEnv for details. In
-// addition, the environment variable RUBRIK_POLARIS_SERVICEACCOUNT_FILE can be
+// addition, the environment variable RUBRIK_SERVICEACCOUNT_FILE can be
 // used to override the file that the service account is read from.
 func ServiceAccountFromFile(file string, allowEnvOverride bool) (*ServiceAccount, error) {
 	if allowEnvOverride {
-		if val := os.Getenv(keyServiceAccountFile); val != "" {
+		if val := env.Get(keyServiceAccountFile); val != "" {
 			file = val
 		}
 	}
@@ -587,7 +589,7 @@ func ServiceAccountFromFile(file string, allowEnvOverride bool) (*ServiceAccount
 //
 // If allowEnvOverride is true environment variables can be used to override
 // account information in the file. See ServiceAccountFromEnv for details. In
-// addition, the environment variable RUBRIK_POLARIS_SERVICEACCOUNT_FILE can be
+// addition, the environment variable RUBRIK_SERVICEACCOUNT_FILE can be
 // used to override the file that the service account is read from.
 func ServiceAccountFromText(text string, allowEnvOverride bool) (*ServiceAccount, error) {
 	account, err := serviceAccountFromString(text)
@@ -610,23 +612,23 @@ func ServiceAccountFromText(text string, allowEnvOverride bool) (*ServiceAccount
 // serviceAccountFromEnv returns a ServiceAccount from the current environment.
 func serviceAccountFromEnv() ServiceAccount {
 	var account ServiceAccount
-	if val := os.Getenv(keyServiceAccountCredentials); val != "" {
+	if val := env.Get(keyServiceAccountCredentials); val != "" {
 		var credAccount ServiceAccount
 		if err := json.Unmarshal([]byte(val), &credAccount); err == nil {
 			account = credAccount
 		}
 	}
 
-	if val := os.Getenv(keyServiceAccountName); val != "" {
+	if val := env.Get(keyServiceAccountName); val != "" {
 		account.Name = val
 	}
-	if val := os.Getenv(keyServiceAccountClientID); val != "" {
+	if val := env.Get(keyServiceAccountClientID); val != "" {
 		account.ClientID = val
 	}
-	if val := os.Getenv(keyServiceAccountClientSecret); val != "" {
+	if val := env.Get(keyServiceAccountClientSecret); val != "" {
 		account.ClientSecret = val
 	}
-	if val := os.Getenv(keyServiceAccountAccessTokenURI); val != "" {
+	if val := env.Get(keyServiceAccountAccessTokenURI); val != "" {
 		account.AccessTokenURI = val
 	}
 

--- a/pkg/polaris/config_test.go
+++ b/pkg/polaris/config_test.go
@@ -699,6 +699,7 @@ func assertErrPrefix(t *testing.T, err error, errPrefix string) bool {
 func dropEnvs(t *testing.T, keys ...string) {
 	for _, key := range keys {
 		t.Setenv(key, "")
+		t.Setenv(strings.Replace(key, "RUBRIK_", "RUBRIK_POLARIS_", 1), "")
 	}
 }
 

--- a/pkg/polaris/polaris.go
+++ b/pkg/polaris/polaris.go
@@ -30,6 +30,7 @@ import (
 	"strconv"
 	"strings"
 
+	"github.com/rubrikinc/rubrik-polaris-sdk-for-go/internal/env"
 	"github.com/rubrikinc/rubrik-polaris-sdk-for-go/pkg/polaris/graphql"
 	"github.com/rubrikinc/rubrik-polaris-sdk-for-go/pkg/polaris/log"
 	"github.com/rubrikinc/rubrik-polaris-sdk-for-go/pkg/polaris/token"
@@ -37,10 +38,10 @@ import (
 
 const (
 	// Client environmental variables.
-	keyLogLevel         = "RUBRIK_POLARIS_LOGLEVEL"
-	keyTokenCache       = "RUBRIK_POLARIS_TOKEN_CACHE"
-	keyTokenCacheDir    = "RUBRIK_POLARIS_TOKEN_CACHE_DIR"
-	keyTokenCacheSecret = "RUBRIK_POLARIS_TOKEN_CACHE_SECRET"
+	keyLogLevel         = "RUBRIK_LOGLEVEL"
+	keyTokenCache       = "RUBRIK_TOKEN_CACHE"
+	keyTokenCacheDir    = "RUBRIK_TOKEN_CACHE_DIR"
+	keyTokenCacheSecret = "RUBRIK_TOKEN_CACHE_SECRET"
 )
 
 // CacheParams is used to configure the token cache.
@@ -62,7 +63,7 @@ type Client struct {
 // NewClient returns a new Client for the specified Account.
 //
 // The client will cache authentication tokens by default, this behavior can be
-// overridden by setting the environment variable RUBRIK_POLARIS_TOKEN_CACHE to
+// overridden by setting the environment variable RUBRIK_TOKEN_CACHE to
 // false, given that the account specified allows environment variable
 // overrides.
 func NewClient(account Account) (*Client, error) {
@@ -80,7 +81,7 @@ func NewClientWithCacheParams(account Account, cacheParams CacheParams) (*Client
 // NewClientWithLogger returns a new Client for the specified Account.
 //
 // The client will cache authentication tokens by default, this behavior can be
-// overridden by setting the environment variable RUBRIK_POLARIS_TOKEN_CACHE to
+// overridden by setting the environment variable RUBRIK_TOKEN_CACHE to
 // false, given that the account specified allows environment variable
 // overrides.
 func NewClientWithLogger(account Account, logger log.Logger) (*Client, error) {
@@ -94,15 +95,15 @@ func NewClientWithLogger(account Account, logger log.Logger) (*Client, error) {
 // variables if the specified account allows environment variable overrides.
 func NewClientWithLoggerAndCacheParams(account Account, cacheParams CacheParams, logger log.Logger) (*Client, error) {
 	if account.allowEnvOverride() {
-		if val := os.Getenv(keyTokenCache); val != "" {
+		if val := env.Get(keyTokenCache); val != "" {
 			if b, err := strconv.ParseBool(val); err != nil {
 				cacheParams.Enable = b
 			}
 		}
-		if val := os.Getenv(keyTokenCacheDir); val != "" {
+		if val := env.Get(keyTokenCacheDir); val != "" {
 			cacheParams.Dir = val
 		}
-		if val := os.Getenv(keyTokenCacheSecret); val != "" {
+		if val := env.Get(keyTokenCacheSecret); val != "" {
 			cacheParams.Secret = val
 		}
 	}
@@ -154,9 +155,9 @@ func (c *Client) SetLogger(logger log.Logger) {
 }
 
 // SetLogLevelFromEnv sets the log level of the logger to the log level
-// specified in the RUBRIK_POLARIS_LOGLEVEL environment variable.
+// specified in the RUBRIK_LOGLEVEL environment variable.
 func SetLogLevelFromEnv(logger log.Logger) error {
-	level := os.Getenv(keyLogLevel)
+	level := env.Get(keyLogLevel)
 	if level == "" {
 		return nil
 	}

--- a/pkg/polaris/token/cache.go
+++ b/pkg/polaris/token/cache.go
@@ -33,8 +33,6 @@ import (
 	"os"
 	"path/filepath"
 	"time"
-
-	"github.com/rubrikinc/rubrik-polaris-sdk-for-go/internal/env"
 )
 
 const (
@@ -69,32 +67,6 @@ func NewCacheWithDir(source Source, dir, keyMaterial, suffixMaterial string) (*c
 		block:  block,
 		file:   filepath.Join(dir, fmt.Sprintf("token-%s", suffix)),
 	}, nil
-}
-
-// Deprecated: Use NewCacheWithDir instead.
-func NewCache(source Source, keyMaterial, suffixMaterial string, allowEnvOverride bool) (*cache, error) {
-	suffix := fmt.Sprintf("%x", sha256.Sum256([]byte(suffixMaterial)))
-	if allowEnvOverride {
-		if tcSecret := env.Get("RUBRIK_TOKEN_CACHE_SECRET"); tcSecret != "" {
-			keyMaterial = tcSecret
-			suffix += "-env"
-		}
-	}
-	key := sha256.Sum256([]byte(keyMaterial))
-	block, err := aes.NewCipher(key[:])
-	if err != nil {
-		return nil, err
-	}
-
-	path := os.TempDir()
-	if allowEnvOverride {
-		if tcDir := env.Get("RUBRIK_TOKEN_CACHE_DIR"); tcDir != "" {
-			path = tcDir
-		}
-	}
-	path = filepath.Join(path, fmt.Sprintf("token-%s", suffix))
-
-	return &cache{source: source, block: block, file: path}, nil
 }
 
 // token returns the cached token. If the cache is empty or the cached token has

--- a/pkg/polaris/token/cache.go
+++ b/pkg/polaris/token/cache.go
@@ -33,6 +33,8 @@ import (
 	"os"
 	"path/filepath"
 	"time"
+
+	"github.com/rubrikinc/rubrik-polaris-sdk-for-go/internal/env"
 )
 
 const (
@@ -73,7 +75,7 @@ func NewCacheWithDir(source Source, dir, keyMaterial, suffixMaterial string) (*c
 func NewCache(source Source, keyMaterial, suffixMaterial string, allowEnvOverride bool) (*cache, error) {
 	suffix := fmt.Sprintf("%x", sha256.Sum256([]byte(suffixMaterial)))
 	if allowEnvOverride {
-		if tcSecret := os.Getenv("RUBRIK_POLARIS_TOKEN_CACHE_SECRET"); tcSecret != "" {
+		if tcSecret := env.Get("RUBRIK_TOKEN_CACHE_SECRET"); tcSecret != "" {
 			keyMaterial = tcSecret
 			suffix += "-env"
 		}
@@ -86,7 +88,7 @@ func NewCache(source Source, keyMaterial, suffixMaterial string, allowEnvOverrid
 
 	path := os.TempDir()
 	if allowEnvOverride {
-		if tcDir := os.Getenv("RUBRIK_POLARIS_TOKEN_CACHE_DIR"); tcDir != "" {
+		if tcDir := env.Get("RUBRIK_TOKEN_CACHE_DIR"); tcDir != "" {
 			path = tcDir
 		}
 	}


### PR DESCRIPTION
# Description

Support the shorter `RUBRIK_` prefix for all environment variables, falling back to the existing `RUBRIK_POLARIS_` prefix for backwards compatibility. The `env.Get` helper in the new `internal/env` package checks the new name first, then derives the `RUBRIK_POLARIS_` variant automatically.

## Related Issue

Part of the provider rename from `rubrikinc/polaris` to `rubrikinc/rubrik`.

## Motivation and Context

With the provider rename, users should be able to use the shorter `RUBRIK_` prefixed environment variables (e.g., `RUBRIK_SERVICEACCOUNT_FILE` instead of `RUBRIK_POLARIS_SERVICEACCOUNT_FILE`). Existing `RUBRIK_POLARIS_` variables continue to work for backwards compatibility.

## How Has This Been Tested?

* Build and vet pass
* CI pipeline will be run after PR creation

## Types of changes

- [ ] Bug fix (non-breaking change which fixes an issue)
- [x] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)

## Checklist:

- [x] My code follows the code style of this project.
- [ ] My change requires a change to the documentation.
- [ ] I have updated the documentation accordingly.
- [ ] I have updated the CHANGELOG file accordingly for the version that this merge modifies.
- [ ] I have added tests to cover my changes.
- [x] All new and existing tests passed.