### PR TITLE
Add option to skip the validation step when adding Azure Exocompute

### DIFF
--- a/pkg/polaris/exocompute/exocompute_azure.go
+++ b/pkg/polaris/exocompute/exocompute_azure.go
@@ -162,7 +162,10 @@ func (a API) AddAzureConfiguration(ctx context.Context, cloudAccountID uuid.UUID
 	}
 
 	if err := exocompute.ValidateConfiguration(ctx, a.client, exoConfig); err != nil {
-		return uuid.Nil, fmt.Errorf("failed to validate exocompute configuration: %s", err)
+		if !exoConfig.SkipValidation {
+			return uuid.Nil, fmt.Errorf("failed to validate exocompute configuration: %s", err)
+		}
+		a.log.Printf(log.Warn, "exocompute configuration validation failed (proceeding anyway): %s", err)
 	}
 
 	configID, err := exocompute.CreateConfiguration(ctx, a.client, exoConfig)

--- a/pkg/polaris/graphql/exocompute/config_azure.go
+++ b/pkg/polaris/graphql/exocompute/config_azure.go
@@ -83,6 +83,10 @@ type CreateAzureConfigurationParams struct {
 	// When true, a health check will be triggered after the configuration is
 	// created.
 	TriggerHealthCheck bool `json:"-"`
+
+	// When true, a failed validation check will not block configuration
+	// creation.
+	SkipValidation bool `json:"-"`
 }
 
 func (p CreateAzureConfigurationParams) CreateQuery() (string, any, CreateAzureConfigurationResult) {


### PR DESCRIPTION
# Description

Adds the ability to ignore the outcome of the validation step when creating Azure Exocompute resources.

## Related Issue

https://github.com/rubrikinc/terraform-provider-polaris/issues/441

## Motivation and Context

Currently a validation API call is run prior to adding the Exocompute configuration, if this validation returns a failure then the addition is never attempted. However, there are scenarios where the validation is only a warning, such as when private DNS zones are in a different subscription. In the portal this warning can be ignored, however this is not possible in the SDK.

## How Has This Been Tested?

Tested using a build of the Terraform provider that has been updated to use this functionality. 

## Screenshots (if appropriate):

## Types of changes

What types of changes does your code introduce? Put an `x` in all the boxes that apply:
- [ ] Bug fix (non-breaking change which fixes an issue)
- [X] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)

## Checklist:

Go over all the following points, and put an `x` in all the boxes that apply. If you're unsure about any of these, don't hesitate to ask. We're here to help!
- [X] My code follows the code style of this project.
- [ ] My change requires a change to the documentation.
- [ ] I have updated the documentation accordingly.
- [ ] I have updated the CHANGELOG file accordingly for the version that this merge modifies.
- [ ] I have added tests to cover my changes.
- [X] All new and existing tests passed.
