### PR TITLE
Distinguish rubrik and polaris provider in Sdk-Language header

### DIFF
--- a/pkg/polaris/graphql/graphql.go
+++ b/pkg/polaris/graphql/graphql.go
@@ -289,7 +289,7 @@ func (c *Client) RequestWithoutRetry(ctx context.Context, query string, variable
 			sdkHeaders.lang = "terraform/go"
 		case "github.com/rubrikinc/terraform-provider-polaris":
 			sdkHeaders.ver = strings.TrimPrefix(buildInfo.Main.Version, "v")
-			sdkHeaders.lang = "terraform_polaris/go"
+			sdkHeaders.lang = "terraform_legacy/go"
 		}
 	})
 

--- a/pkg/polaris/graphql/graphql.go
+++ b/pkg/polaris/graphql/graphql.go
@@ -283,9 +283,13 @@ func (c *Client) RequestWithoutRetry(ctx context.Context, query string, variable
 		// The terraform provider gets special treatment here, since we want
 		// to distinguish it from the SDK without exposing the possibility to
 		// set the version from outside.
-		if buildInfo.Main.Path == "github.com/rubrikinc/terraform-provider-polaris" {
+		switch buildInfo.Main.Path {
+		case "github.com/rubrikinc/terraform-provider-rubrik":
 			sdkHeaders.ver = strings.TrimPrefix(buildInfo.Main.Version, "v")
 			sdkHeaders.lang = "terraform/go"
+		case "github.com/rubrikinc/terraform-provider-polaris":
+			sdkHeaders.ver = strings.TrimPrefix(buildInfo.Main.Version, "v")
+			sdkHeaders.lang = "terraform_polaris/go"
 		}
 	})
 


### PR DESCRIPTION
# Description

Recognizes the renamed ``terraform-provider-rubrik`` module path in the build-info inspection that sets the ``Sdk-Language`` and ``Sdk-Version`` request headers. The renamed provider is now identified as ``terraform/go`` -- the original tag previously used by ``terraform-provider-polaris``. The legacy ``terraform-provider-polaris`` module path now reports as ``terraform_polaris/go``, so the backend can distinguish traffic originating from the renamed provider from traffic still going through the legacy provider.

## Related Issue

N/A.

## Motivation and Context

After the provider was renamed from ``rubrikinc/polaris`` to ``rubrikinc/rubrik`` in v1.7.0, both providers ship in parallel and call into the SDK. Without this change, requests from the renamed ``terraform-provider-rubrik`` would fall through the build-info match and report as plain ``go`` rather than as a Terraform provider, and the backend would have no way to tell the two providers apart in telemetry. Treating ``terraform-provider-rubrik`` as the going-forward owner of the ``terraform/go`` tag and reassigning the legacy provider to ``terraform_polaris/go`` keeps Terraform traffic visible while making the legacy traffic distinguishable.

## How Has This Been Tested?

By running the unit tests.

## Types of changes

What types of changes does your code introduce? Put an \`x\` in all the boxes that apply:
- [ ] Bug fix (non-breaking change which fixes an issue)
- [x] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)

## Checklist:

Go over all the following points, and put an \`x\` in all the boxes that apply. If you're unsure about any of these, don't hesitate to ask. We're here to help!
- [x] My code follows the code style of this project.
- [ ] My change requires a change to the documentation.
- [ ] I have updated the documentation accordingly.
- [ ] I have updated the CHANGELOG file accordingly for the version that this merge modifies.
- [ ] I have added tests to cover my changes.
- [X] All new and existing tests passed.