### PR TITLE
Add AllProtectionFeatures helper

### DIFF
--- a/pkg/polaris/graphql/core/core.go
+++ b/pkg/polaris/graphql/core/core.go
@@ -253,6 +253,35 @@ var validFeatures = map[string]struct{}{
 	FeatureServerAndApps.Name:                           {},
 }
 
+// AllProtectionFeatures returns the protection features for the specified cloud
+// vendor.
+func AllProtectionFeatures(cloud CloudVendor) []Feature {
+	switch cloud {
+	case CloudVendorAWS:
+		return []Feature{
+			FeatureCloudNativeDynamoDBProtection,
+			FeatureCloudNativeProtection,
+			FeatureCloudNativeS3Protection,
+			FeatureKubernetesProtection,
+			FeatureRDSProtection,
+		}
+	case CloudVendorAzure:
+		return []Feature{
+			FeatureAzureSQLDBProtection,
+			FeatureAzureSQLMIProtection,
+			FeatureCloudNativeBlobProtection,
+			FeatureCloudNativeProtection,
+			FeatureKubernetesProtection,
+		}
+	case CloudVendorGCP:
+		return []Feature{
+			FeatureCloudNativeProtection,
+		}
+	default:
+		return nil
+	}
+}
+
 // FeatureNames returns the names of the features.
 func FeatureNames(features []Feature) []string {
 	var names []string


### PR DESCRIPTION
# Description

Add `AllProtectionFeatures(cloud CloudVendor) []Feature` to the `core` package. The helper returns the protection features supported for a given cloud vendor: AWS returns five features, Azure returns five, GCP returns one, and any other vendor returns nil.

## Related Issue

N/A — small helper addition.

## Motivation and Context

Lets callers iterate over the protection features for a cloud without hard-coding the list at every call site.

## How Has This Been Tested?

`go build ./...` and `go test ./...`.

## Screenshots (if appropriate):

## Types of changes

What types of changes does your code introduce? Put an `x` in all the boxes that apply:
- [ ] Bug fix (non-breaking change which fixes an issue)
- [x] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)
- [ ] Other (please describe in the Description above)

## Checklist:

Go over all the following points, and put an `x` in all the boxes that apply. If you're unsure about any of these, don't hesitate to ask. We're here to help!
- [x] My code follows the code style of this project.
- [ ] My change requires a change to the documentation.
- [ ] I have updated the documentation accordingly.
- [ ] I have updated the CHANGELOG file accordingly for the version that this merge modifies.
- [ ] I have added tests to cover my changes.
- [x] All new and existing tests passed.