### PR TITLE
Add self-serve rolling upgrade API

### DIFF
--- a/pkg/polaris/cluster/upgrade.go
+++ b/pkg/polaris/cluster/upgrade.go
@@ -1,0 +1,52 @@
+// Copyright 2026 Rubrik, Inc.
+//
+// Permission is hereby granted, free of charge, to any person obtaining a copy
+// of this software and associated documentation files (the "Software"), to
+// deal in the Software without restriction, including without limitation the
+// rights to use, copy, modify, merge, publish, distribute, sublicense, and/or
+// sell copies of the Software, and to permit persons to whom the Software is
+// furnished to do so, subject to the following conditions:
+//
+// The above copyright notice and this permission notice shall be included in
+// all copies or substantial portions of the Software.
+//
+// THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+// IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+// FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+// AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+// LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING
+// FROM, OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER
+// DEALINGS IN THE SOFTWARE.
+
+package cluster
+
+import (
+	"context"
+	"fmt"
+
+	gqlcluster "github.com/rubrikinc/rubrik-polaris-sdk-for-go/pkg/polaris/graphql/cluster"
+	"github.com/rubrikinc/rubrik-polaris-sdk-for-go/pkg/polaris/log"
+)
+
+// SelfServeRollingUpgrade returns whether the account-level self-serve
+// rolling upgrade setting is enabled.
+func (a API) SelfServeRollingUpgrade(ctx context.Context) (bool, error) {
+	a.log.Print(log.Trace)
+
+	enabled, err := gqlcluster.SelfServeRollingUpgrade(ctx, a.client.GQL)
+	if err != nil {
+		return false, fmt.Errorf("failed to read self-serve rolling upgrade setting: %s", err)
+	}
+	return enabled, nil
+}
+
+// SetSelfServeRollingUpgrade sets the account-level self-serve rolling upgrade
+// setting to the specified value.
+func (a API) SetSelfServeRollingUpgrade(ctx context.Context, enabled bool) error {
+	a.log.Print(log.Trace)
+
+	if err := gqlcluster.SetSelfServeRollingUpgrade(ctx, a.client.GQL, enabled); err != nil {
+		return fmt.Errorf("failed to set self-serve rolling upgrade: %s", err)
+	}
+	return nil
+}

--- a/pkg/polaris/graphql/cluster/queries.go
+++ b/pkg/polaris/graphql/cluster/queries.go
@@ -121,6 +121,22 @@ var removeCdmClusterQuery = `mutation SdkGolangRemoveCdmCluster($clusterUuid: UU
   )
 }`
 
+// selfServeRollingUpgrade GraphQL query
+var selfServeRollingUpgradeQuery = `query SdkGolangSelfServeRollingUpgrade {
+  result: selfServeRollingUpgrade {
+    enabled
+  }
+}`
+
+// setSelfServeRollingUpgrade GraphQL query
+var setSelfServeRollingUpgradeQuery = `mutation SdkGolangSetSelfServeRollingUpgrade($enabled: Boolean!) {
+  result: setSelfServeRollingUpgrade(input: {
+    enabled: $enabled,
+  }) {
+    enabled
+  }
+}`
+
 // slaSourceClusters GraphQL query
 var slaSourceClustersQuery = `query SdkGolangSlaSourceClusters(
   $after: String

--- a/pkg/polaris/graphql/cluster/queries/self_serve_rolling_upgrade.graphql
+++ b/pkg/polaris/graphql/cluster/queries/self_serve_rolling_upgrade.graphql
@@ -1,0 +1,5 @@
+query RubrikPolarisSDKRequest {
+  result: selfServeRollingUpgrade {
+    enabled
+  }
+}

--- a/pkg/polaris/graphql/cluster/queries/set_self_serve_rolling_upgrade.graphql
+++ b/pkg/polaris/graphql/cluster/queries/set_self_serve_rolling_upgrade.graphql
@@ -1,0 +1,7 @@
+mutation RubrikPolarisSDKRequest($enabled: Boolean!) {
+  result: setSelfServeRollingUpgrade(input: {
+    enabled: $enabled,
+  }) {
+    enabled
+  }
+}

--- a/pkg/polaris/graphql/cluster/upgrade.go
+++ b/pkg/polaris/graphql/cluster/upgrade.go
@@ -1,0 +1,83 @@
+// Copyright 2026 Rubrik, Inc.
+//
+// Permission is hereby granted, free of charge, to any person obtaining a copy
+// of this software and associated documentation files (the "Software"), to
+// deal in the Software without restriction, including without limitation the
+// rights to use, copy, modify, merge, publish, distribute, sublicense, and/or
+// sell copies of the Software, and to permit persons to whom the Software is
+// furnished to do so, subject to the following conditions:
+//
+// The above copyright notice and this permission notice shall be included in
+// all copies or substantial portions of the Software.
+//
+// THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+// IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+// FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+// AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+// LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING
+// FROM, OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER
+// DEALINGS IN THE SOFTWARE.
+
+package cluster
+
+import (
+	"context"
+	"encoding/json"
+	"fmt"
+
+	"github.com/rubrikinc/rubrik-polaris-sdk-for-go/pkg/polaris/graphql"
+	"github.com/rubrikinc/rubrik-polaris-sdk-for-go/pkg/polaris/log"
+)
+
+// SelfServeRollingUpgrade returns whether self-serve rolling upgrade is
+// enabled for the account.
+func SelfServeRollingUpgrade(ctx context.Context, gql *graphql.Client) (bool, error) {
+	gql.Log().Print(log.Trace)
+
+	query := selfServeRollingUpgradeQuery
+	buf, err := gql.Request(ctx, query, struct{}{})
+	if err != nil {
+		return false, graphql.RequestError(query, err)
+	}
+
+	var payload struct {
+		Data struct {
+			Result struct {
+				Enabled bool `json:"enabled"`
+			} `json:"result"`
+		} `json:"data"`
+	}
+	if err := json.Unmarshal(buf, &payload); err != nil {
+		return false, graphql.UnmarshalError(query, err)
+	}
+	return payload.Data.Result.Enabled, nil
+}
+
+// SetSelfServeRollingUpgrade sets the account-level self-serve rolling upgrade
+// setting to the specified value.
+func SetSelfServeRollingUpgrade(ctx context.Context, gql *graphql.Client, enabled bool) error {
+	gql.Log().Print(log.Trace)
+
+	query := setSelfServeRollingUpgradeQuery
+	buf, err := gql.Request(ctx, query, struct {
+		Enabled bool `json:"enabled"`
+	}{Enabled: enabled})
+	if err != nil {
+		return graphql.RequestError(query, err)
+	}
+
+	var payload struct {
+		Data struct {
+			Result struct {
+				Enabled bool `json:"enabled"`
+			} `json:"result"`
+		} `json:"data"`
+	}
+	if err := json.Unmarshal(buf, &payload); err != nil {
+		return graphql.UnmarshalError(query, err)
+	}
+	if payload.Data.Result.Enabled != enabled {
+		return graphql.ResponseError(query, fmt.Errorf("self-serve rolling upgrade not set: requested %t, got %t", enabled, payload.Data.Result.Enabled))
+	}
+	return nil
+}


### PR DESCRIPTION
# Description

Adds SelfServeRollingUpgrade and SetSelfServeRollingUpgrade for reading and updating the account-level self-serve rolling upgrade setting, both as low-level GraphQL bindings and high-level cluster API methods.

## Motivation and Context

Part of Cluster upgrade support.

## How Has This Been Tested?

Manually read and toggle the value.

## Types of changes

What types of changes does your code introduce? Put an `x` in all the boxes that apply:
- [ ] Bug fix (non-breaking change which fixes an issue)
- [x] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)
- [ ] Other (please describe in the Description above)

## Checklist:

Go over all the following points, and put an `x` in all the boxes that apply. If you're unsure about any of these, don't hesitate to ask. We're here to help!
- [x] My code follows the code style of this project.
- [ ] My change requires a change to the documentation.
- [ ] I have updated the documentation accordingly.
- [ ] I have updated the CHANGELOG file accordingly for the version that this merge modifies.
- [ ] I have added tests to cover my changes.
- [x] All new and existing tests passed.
