### PR TITLE
Add OnboardingMode helper for AWS cloud accounts

### DIFF
--- a/pkg/polaris/aws/cloud_account.go
+++ b/pkg/polaris/aws/cloud_account.go
@@ -12,6 +12,20 @@ import (
 	"github.com/rubrikinc/rubrik-polaris-sdk-for-go/pkg/polaris/log"
 )
 
+// OnboardingMode identifies the workflow used to onboard an AWS account or
+// feature into RSC.
+type OnboardingMode string
+
+const (
+	// OnboardingModeCFT indicates onboarding via the CloudFormation workflow.
+	OnboardingModeCFT OnboardingMode = "CFT"
+
+	// OnboardingModeIAM indicates onboarding via the IAM workflow, where the
+	// caller provides their own IAM roles instead of letting RSC create them
+	// via a CloudFormation stack.
+	OnboardingModeIAM OnboardingMode = "IAM"
+)
+
 // CloudAccount for Amazon Web Services accounts.
 type CloudAccount struct {
 	Cloud                 string
@@ -31,6 +45,18 @@ func (c CloudAccount) Feature(feature core.Feature) (Feature, bool) {
 	}
 
 	return Feature{}, false
+}
+
+// OnboardingMode returns the onboarding workflow used for the account. An
+// account is considered CFT-onboarded if any of its features was onboarded
+// via the CloudFormation workflow.
+func (c CloudAccount) OnboardingMode() OnboardingMode {
+	for _, feature := range c.Features {
+		if feature.OnboardingMode() == OnboardingModeCFT {
+			return OnboardingModeCFT
+		}
+	}
+	return OnboardingModeIAM
 }
 
 type MappedAccount struct {
@@ -65,6 +91,16 @@ func (f Feature) HasRegion(region string) bool {
 	}
 
 	return false
+}
+
+// OnboardingMode returns the onboarding workflow used for this feature.
+// CFT-onboarded features carry a CloudFormation stack ARN, IAM-onboarded
+// features do not.
+func (f Feature) OnboardingMode() OnboardingMode {
+	if f.StackArn != "" {
+		return OnboardingModeCFT
+	}
+	return OnboardingModeIAM
 }
 
 // AccountByID returns the account with the specified RSC cloud account ID.

--- a/pkg/polaris/aws/cloud_account_cft_test.go
+++ b/pkg/polaris/aws/cloud_account_cft_test.go
@@ -93,6 +93,12 @@ func TestAwsAccountAddAndRemoveWithCFT(t *testing.T) {
 	if account.Features[0].Status != core.StatusConnected {
 		t.Fatalf("invalid feature status: %v", account.Features[0].Status)
 	}
+	if mode := account.OnboardingMode(); mode != OnboardingModeCFT {
+		t.Fatalf("invalid onboarding mode: %v", mode)
+	}
+	if mode := account.Features[0].OnboardingMode(); mode != OnboardingModeCFT {
+		t.Fatalf("invalid feature onboarding mode: %v", mode)
+	}
 
 	// Update and verify regions for AWS account.
 	err = awsClient.UpdateAccount(ctx, account.ID, core.FeatureCloudNativeProtection, Regions("us-west-2"))
@@ -205,6 +211,15 @@ func TestAwsAccountAddAndRemoveUsingPermissionGroupsWithCFT(t *testing.T) {
 	if groups := account.Features[1].PermissionGroups; !reflect.DeepEqual(groups, []core.PermissionGroup{core.PermissionGroupBasic, core.PermissionGroupRSCManagedCluster}) {
 		t.Fatalf("invalid permission groups: %v", groups)
 	}
+	if mode := account.OnboardingMode(); mode != OnboardingModeCFT {
+		t.Fatalf("invalid onboarding mode: %v", mode)
+	}
+	if mode := account.Features[0].OnboardingMode(); mode != OnboardingModeCFT {
+		t.Fatalf("invalid feature[0] onboarding mode: %v", mode)
+	}
+	if mode := account.Features[1].OnboardingMode(); mode != OnboardingModeCFT {
+		t.Fatalf("invalid feature[1] onboarding mode: %v", mode)
+	}
 	// Remove AWS account from RSC.
 	err = awsClient.RemoveAccountWithCFT(ctx, Profile(testAccount.Profile), features, false)
 	if err != nil {
@@ -276,6 +291,12 @@ func TestAwsCrossAccountAddAndRemoveWithCFT(t *testing.T) {
 	}
 	if account.Features[0].Status != core.StatusConnected {
 		t.Fatalf("invalid feature status: %v", account.Features[0].Status)
+	}
+	if mode := account.OnboardingMode(); mode != OnboardingModeCFT {
+		t.Fatalf("invalid onboarding mode: %v", mode)
+	}
+	if mode := account.Features[0].OnboardingMode(); mode != OnboardingModeCFT {
+		t.Fatalf("invalid feature onboarding mode: %v", mode)
 	}
 
 	// Verify that it's possible to find the account using the account ID

--- a/pkg/polaris/aws/cloud_account_test.go
+++ b/pkg/polaris/aws/cloud_account_test.go
@@ -1,0 +1,90 @@
+// Copyright 2026 Rubrik, Inc.
+//
+// Permission is hereby granted, free of charge, to any person obtaining a copy
+// of this software and associated documentation files (the "Software"), to
+// deal in the Software without restriction, including without limitation the
+// rights to use, copy, modify, merge, publish, distribute, sublicense, and/or
+// sell copies of the Software, and to permit persons to whom the Software is
+// furnished to do so, subject to the following conditions:
+//
+// The above copyright notice and this permission notice shall be included in
+// all copies or substantial portions of the Software.
+//
+// THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+// IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+// FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+// AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+// LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING
+// FROM, OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER
+// DEALINGS IN THE SOFTWARE.
+
+package aws
+
+import "testing"
+
+func TestFeatureOnboardingMode(t *testing.T) {
+	tests := []struct {
+		name     string
+		feature  Feature
+		expected OnboardingMode
+	}{{
+		name:     "Empty stack ARN is IAM",
+		feature:  Feature{},
+		expected: OnboardingModeIAM,
+	}, {
+		name:     "Non-empty stack ARN is CFT",
+		feature:  Feature{StackArn: "arn:aws:cloudformation:us-east-1:123456789012:stack/rsc"},
+		expected: OnboardingModeCFT,
+	}}
+
+	for _, tc := range tests {
+		t.Run(tc.name, func(t *testing.T) {
+			if mode := tc.feature.OnboardingMode(); mode != tc.expected {
+				t.Fatalf("expected %v, got %v", tc.expected, mode)
+			}
+		})
+	}
+}
+
+func TestCloudAccountOnboardingMode(t *testing.T) {
+	cft := Feature{StackArn: "arn:aws:cloudformation:us-east-1:123456789012:stack/rsc"}
+	iam := Feature{}
+
+	tests := []struct {
+		name     string
+		account  CloudAccount
+		expected OnboardingMode
+	}{{
+		name:     "No features is IAM",
+		account:  CloudAccount{},
+		expected: OnboardingModeIAM,
+	}, {
+		name:     "Single IAM feature is IAM",
+		account:  CloudAccount{Features: []Feature{iam}},
+		expected: OnboardingModeIAM,
+	}, {
+		name:     "Multiple IAM features is IAM",
+		account:  CloudAccount{Features: []Feature{iam, iam, iam}},
+		expected: OnboardingModeIAM,
+	}, {
+		name:     "Single CFT feature is CFT",
+		account:  CloudAccount{Features: []Feature{cft}},
+		expected: OnboardingModeCFT,
+	}, {
+		name:     "Multiple CFT features is CFT",
+		account:  CloudAccount{Features: []Feature{cft, cft}},
+		expected: OnboardingModeCFT,
+	}, {
+		name:     "Mixed CFT and IAM features is CFT",
+		account:  CloudAccount{Features: []Feature{iam, cft, iam}},
+		expected: OnboardingModeCFT,
+	}}
+
+	for _, tc := range tests {
+		t.Run(tc.name, func(t *testing.T) {
+			if mode := tc.account.OnboardingMode(); mode != tc.expected {
+				t.Fatalf("expected %v, got %v", tc.expected, mode)
+			}
+		})
+	}
+}


### PR DESCRIPTION
# Description

Adds an `OnboardingMode` accessor that distinguishes accounts and features onboarded via the CloudFormation (CFT) workflow from those onboarded via the IAM workflow. CFT-onboarded features carry a CloudFormation stack ARN, IAM-onboarded features do not. The accessor lives at two levels:

- `Feature.OnboardingMode() OnboardingMode` — per-feature, returns CFT if `StackArn` is set, otherwise IAM.
- `CloudAccount.OnboardingMode() OnboardingMode` — aggregate, returns CFT if any feature was onboarded via CFT, otherwise IAM. An account with no features returns IAM.

Backed by an `OnboardingMode` typed string with constants `OnboardingModeCFT` and `OnboardingModeIAM`.

## How Has This Been Tested?

Unit tests in `pkg/polaris/aws/cloud_account_test.go` cover both methods table-driven (empty, single, multiple, mixed-mode feature lists). All 8 subtests pass.

Integration assertions added to the three existing CFT tests in `pkg/polaris/aws/cloud_account_cft_test.go` verify that real CFT-onboarded accounts and features return `OnboardingModeCFT`. Ran against a live RSC instance with `TEST_INTEGRATION=1`:

- `TestAwsAccountAddAndRemoveWithCFT` — PASS (206.29s)
- `TestAwsAccountAddAndRemoveUsingPermissionGroupsWithCFT` — PASS (274.77s)
- `TestAwsCrossAccountAddAndRemoveWithCFT` — PASS (110.59s)

## Types of changes

- [ ] Bug fix (non-breaking change which fixes an issue)
- [x] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)
- [ ] Other (please describe in the Description above)

## Checklist:

- [x] My code follows the code style of this project.
- [ ] My change requires a change to the documentation.
- [ ] I have updated the documentation accordingly.
- [ ] I have updated the CHANGELOG file accordingly for the version that this merge modifies.
- [x] I have added tests to cover my changes.
- [x] All new and existing tests passed.