### PR TITLE
Add featuresWithPermissionsGroups to AWS AccountFeatureArtifact

### DIFF
--- a/pkg/polaris/aws/cloud_account_iam.go
+++ b/pkg/polaris/aws/cloud_account_iam.go
@@ -300,9 +300,10 @@ func (a API) AddAccountArtifacts(ctx context.Context, params AddAccountArtifacts
 		mappings, err = aws.Wrap(a.client).RegisterFeatureArtifacts(ctx, aws.RegisterFeatureArtifactsParams{
 			Cloud: aws.Cloud(account.Cloud),
 			Artifacts: []aws.AccountFeatureArtifact{{
-				NativeID:  account.NativeID,
-				Features:  core.FeatureNames(params.Features),
-				Artifacts: externalArtifacts,
+				NativeID:                      account.NativeID,
+				Features:                      core.FeatureNames(params.Features),
+				FeaturesWithPermissionsGroups: params.Features,
+				Artifacts:                     externalArtifacts,
 			}},
 			RoleChainingAccountID: params.RoleChainingAccountID,
 		})

--- a/pkg/polaris/graphql/aws/cloud_no_cft.go
+++ b/pkg/polaris/graphql/aws/cloud_no_cft.go
@@ -135,11 +135,14 @@ func (a API) TrustPolicy(ctx context.Context, params TrustPolicyParams) ([]Trust
 }
 
 // AccountFeatureArtifact holds the artifacts for a cloud account, identified by
-// the native ID.
+// the native ID. FeaturesWithPermissionsGroups carries permission groups for
+// each feature and, when populated, takes precedence over Features on the RSC
+// backend.
 type AccountFeatureArtifact struct {
-	NativeID  string             `json:"awsNativeId"`
-	Features  []string           `json:"features"`
-	Artifacts []ExternalArtifact `json:"externalArtifacts"`
+	NativeID                      string             `json:"awsNativeId"`
+	Features                      []string           `json:"features"`
+	FeaturesWithPermissionsGroups []core.Feature     `json:"featuresWithPermissionsGroups,omitempty"`
+	Artifacts                     []ExternalArtifact `json:"externalArtifacts"`
 }
 
 // ExternalArtifact holds the key and value for an artifact.


### PR DESCRIPTION
Expose the existing AwsAccountFeatureArtifact.featuresWithPermissionsGroups GraphQL input field on the Go SDK so callers can pass permission groups through registerAwsFeatureArtifacts. Populated automatically from the features already supplied to AddAccountArtifacts.

## How Has This Been Tested?

Tested terraform passing in PGs and confirmed not changes.

## Types of changes

What types of changes does your code introduce? Put an `x` in all the boxes that apply:
- [ ] Bug fix (non-breaking change which fixes an issue)
- [X] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)
- [ ] Other (please describe in the Description above)

## Checklist:

Go over all the following points, and put an `x` in all the boxes that apply. If you're unsure about any of these, don't hesitate to ask. We're here to help!
- [ ] My code follows the code style of this project.
- [ ] My change requires a change to the documentation.
- [ ] I have updated the documentation accordingly.
- [ ] I have updated the CHANGELOG file accordingly for the version that this merge modifies.
- [ ] I have added tests to cover my changes.
- [ ] All new and existing tests passed.
