### PR TITLE
Add ListClusterUpgrades and ClusterUpgrade APIs

### DIFF
--- a/pkg/polaris/cluster/upgrade.go
+++ b/pkg/polaris/cluster/upgrade.go
@@ -24,9 +24,63 @@ import (
 	"context"
 	"fmt"
 
+	"github.com/google/uuid"
+	"github.com/rubrikinc/rubrik-polaris-sdk-for-go/pkg/polaris/graphql"
 	gqlcluster "github.com/rubrikinc/rubrik-polaris-sdk-for-go/pkg/polaris/graphql/cluster"
+	"github.com/rubrikinc/rubrik-polaris-sdk-for-go/pkg/polaris/graphql/core"
 	"github.com/rubrikinc/rubrik-polaris-sdk-for-go/pkg/polaris/log"
 )
+
+// listClusterUpgradesPageSize is the per-request page size used when
+// iterating clusterWithUpgradesInfo.
+const listClusterUpgradesPageSize = 50
+
+// ListClusterUpgrades returns the upgrade information for every cluster
+// matching filter, paginating through the underlying connection.
+func (a API) ListClusterUpgrades(ctx context.Context, filter *gqlcluster.CDMInfoFilter, sortBy gqlcluster.UpgradeInfoSortBy, sortOrder core.SortOrder) ([]gqlcluster.UpgradeDetails, error) {
+	a.log.Print(log.Trace)
+
+	pageSize := listClusterUpgradesPageSize
+	page := core.Pagination{First: &pageSize}
+	if sortOrder != "" {
+		page.SortOrder = &sortOrder
+	}
+
+	var details []gqlcluster.UpgradeDetails
+	for {
+		result, err := gqlcluster.ClusterWithUpgradesInfo(ctx, a.client.GQL, filter, sortBy, page)
+		if err != nil {
+			return nil, fmt.Errorf("failed to list cluster upgrades: %s", err)
+		}
+		details = append(details, result.Details...)
+		if !result.PageInfo.HasNextPage || result.PageInfo.EndCursor == "" {
+			return details, nil
+		}
+		if page.After != nil && *page.After == result.PageInfo.EndCursor {
+			return details, nil
+		}
+		cursor := result.PageInfo.EndCursor
+		page.After = &cursor
+	}
+}
+
+// ClusterUpgrade returns the upgrade information for a single cluster.
+// Returns graphql.ErrNotFound when no cluster with that UUID is registered.
+func (a API) ClusterUpgrade(ctx context.Context, clusterID uuid.UUID) (gqlcluster.UpgradeDetails, error) {
+	a.log.Print(log.Trace)
+
+	pageSize := 1
+	page := core.Pagination{First: &pageSize}
+	filter := &gqlcluster.CDMInfoFilter{ID: []uuid.UUID{clusterID}}
+	result, err := gqlcluster.ClusterWithUpgradesInfo(ctx, a.client.GQL, filter, "", page)
+	if err != nil {
+		return gqlcluster.UpgradeDetails{}, fmt.Errorf("failed to get cluster upgrade info: %s", err)
+	}
+	if len(result.Details) == 0 || result.Details[0].ID != clusterID {
+		return gqlcluster.UpgradeDetails{}, fmt.Errorf("cluster %q %w", clusterID, graphql.ErrNotFound)
+	}
+	return result.Details[0], nil
+}
 
 // SelfServeRollingUpgrade returns whether the account-level self-serve
 // rolling upgrade setting is enabled.

--- a/pkg/polaris/cluster/upgrade_test.go
+++ b/pkg/polaris/cluster/upgrade_test.go
@@ -1,0 +1,216 @@
+// Copyright 2026 Rubrik, Inc.
+//
+// Permission is hereby granted, free of charge, to any person obtaining a copy
+// of this software and associated documentation files (the "Software"), to
+// deal in the Software without restriction, including without limitation the
+// rights to use, copy, modify, merge, publish, distribute, sublicense, and/or
+// sell copies of the Software, and to permit persons to whom the Software is
+// furnished to do so, subject to the following conditions:
+//
+// The above copyright notice and this permission notice shall be included in
+// all copies or substantial portions of the Software.
+//
+// THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+// IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+// FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+// AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+// LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING
+// FROM, OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER
+// DEALINGS IN THE SOFTWARE.
+
+package cluster
+
+import (
+	"context"
+	"encoding/json"
+	"errors"
+	"fmt"
+	"net/http"
+	"net/http/httptest"
+	"testing"
+
+	"github.com/google/uuid"
+	"github.com/rubrikinc/rubrik-polaris-sdk-for-go/internal/assert"
+	"github.com/rubrikinc/rubrik-polaris-sdk-for-go/internal/handler"
+	"github.com/rubrikinc/rubrik-polaris-sdk-for-go/pkg/polaris/graphql"
+)
+
+// pageResponse returns a JSON response with the given details, cursor, and
+// hasNextPage flag.
+func pageResponse(cursor string, hasNextPage bool, nodes ...string) string {
+	edges := ""
+	for i, node := range nodes {
+		if i > 0 {
+			edges += ","
+		}
+		edges += fmt.Sprintf(`{"cursor":"c","node":%s}`, node)
+	}
+	return fmt.Sprintf(`{
+        "data": {
+            "result": {
+                "edges": [%s],
+                "pageInfo": {"startCursor":"","endCursor":%q,"hasPreviousPage":false,"hasNextPage":%t},
+                "count": %d
+            }
+        }
+    }`, edges, cursor, hasNextPage, len(nodes))
+}
+
+func TestListClusterUpgradesPaginates(t *testing.T) {
+	ctx, cancel := context.WithCancelCause(context.Background())
+	defer assert.Context(t, ctx, cancel)
+
+	id1 := uuid.MustParse("11111111-1111-1111-1111-111111111111")
+	id2 := uuid.MustParse("22222222-2222-2222-2222-222222222222")
+	id3 := uuid.MustParse("33333333-3333-3333-3333-333333333333")
+	node := func(id uuid.UUID, name string) string {
+		return fmt.Sprintf(`{"id":%q,"name":%q,"cdmUpgradeInfo":{"clusterUuid":%q,"version":"9.2.1"}}`, id, name, id)
+	}
+
+	calls := 0
+	srv := httptest.NewServer(handler.GraphQL(func(w http.ResponseWriter, req *http.Request) {
+		var body struct {
+			Variables map[string]json.RawMessage `json:"variables"`
+		}
+		if err := json.NewDecoder(req.Body).Decode(&body); err != nil {
+			http.Error(w, err.Error(), http.StatusBadRequest)
+			return
+		}
+		calls++
+		switch calls {
+		case 1:
+			if _, ok := body.Variables["after"]; ok {
+				http.Error(w, "first call should have no after cursor", http.StatusBadRequest)
+				return
+			}
+			fmt.Fprint(w, pageResponse("cursor-1", true, node(id1, "a"), node(id2, "b")))
+		case 2:
+			var after string
+			if err := json.Unmarshal(body.Variables["after"], &after); err != nil || after != "cursor-1" {
+				http.Error(w, "second call should send cursor-1", http.StatusBadRequest)
+				return
+			}
+			fmt.Fprint(w, pageResponse("cursor-2", false, node(id3, "c")))
+		default:
+			http.Error(w, "too many calls", http.StatusBadRequest)
+		}
+	}))
+	defer srv.Close()
+
+	api := Wrap(newTestClient(srv))
+	details, err := api.ListClusterUpgrades(ctx, nil, "", "")
+	if err != nil {
+		t.Fatalf("ListClusterUpgrades: %v", err)
+	}
+	if calls != 2 {
+		t.Fatalf("expected 2 calls, got %d", calls)
+	}
+	if len(details) != 3 {
+		t.Fatalf("expected 3 details, got %d", len(details))
+	}
+	wantIDs := []uuid.UUID{id1, id2, id3}
+	for i, d := range details {
+		if d.ID != wantIDs[i] {
+			t.Errorf("details[%d].ID: got %v, want %v", i, d.ID, wantIDs[i])
+		}
+	}
+}
+
+// TestListClusterUpgradesNonAdvancingCursor verifies that a server returning
+// HasNextPage=true with the same EndCursor does not cause an infinite loop.
+func TestListClusterUpgradesNonAdvancingCursor(t *testing.T) {
+	ctx, cancel := context.WithCancelCause(context.Background())
+	defer assert.Context(t, ctx, cancel)
+
+	id1 := uuid.MustParse("11111111-1111-1111-1111-111111111111")
+	node := fmt.Sprintf(`{"id":%q,"name":"a","cdmUpgradeInfo":{"clusterUuid":%q,"version":"9.2.1"}}`, id1, id1)
+
+	calls := 0
+	srv := httptest.NewServer(handler.GraphQL(func(w http.ResponseWriter, req *http.Request) {
+		calls++
+		// Always return the same cursor with HasNextPage=true to simulate a
+		// buggy server. The client must give up rather than loop.
+		fmt.Fprint(w, pageResponse("stuck-cursor", true, node))
+	}))
+	defer srv.Close()
+
+	api := Wrap(newTestClient(srv))
+	details, err := api.ListClusterUpgrades(ctx, nil, "", "")
+	if err != nil {
+		t.Fatalf("ListClusterUpgrades: %v", err)
+	}
+	// Expect two calls: first page (no After), then a second call with
+	// After=stuck-cursor that returns the same cursor — at that point we bail.
+	if calls != 2 {
+		t.Fatalf("expected 2 calls before bailing, got %d", calls)
+	}
+	if len(details) != 2 {
+		t.Fatalf("expected 2 details (one per call before bail), got %d", len(details))
+	}
+}
+
+func TestClusterUpgradeNotFound(t *testing.T) {
+	ctx, cancel := context.WithCancelCause(context.Background())
+	defer assert.Context(t, ctx, cancel)
+
+	srv := httptest.NewServer(handler.GraphQL(func(w http.ResponseWriter, req *http.Request) {
+		fmt.Fprint(w, `{"data":{"result":{"edges":[],"pageInfo":{"hasNextPage":false},"count":0}}}`)
+	}))
+	defer srv.Close()
+
+	api := Wrap(newTestClient(srv))
+	_, err := api.ClusterUpgrade(ctx, uuid.MustParse("11111111-1111-1111-1111-111111111111"))
+	if err == nil {
+		t.Fatal("expected ErrNotFound")
+	}
+	if !errors.Is(err, graphql.ErrNotFound) {
+		t.Errorf("error should wrap ErrNotFound: %v", err)
+	}
+}
+
+func TestClusterUpgradeWrongIDIsNotFound(t *testing.T) {
+	ctx, cancel := context.WithCancelCause(context.Background())
+	defer assert.Context(t, ctx, cancel)
+
+	wantID := uuid.MustParse("11111111-1111-1111-1111-111111111111")
+	otherID := uuid.MustParse("22222222-2222-2222-2222-222222222222")
+	srv := httptest.NewServer(handler.GraphQL(func(w http.ResponseWriter, req *http.Request) {
+		// Server returns a different cluster than the one we asked for.
+		node := fmt.Sprintf(`{"id":%q,"name":"other","cdmUpgradeInfo":{"clusterUuid":%q,"version":"9.2.1"}}`, otherID, otherID)
+		fmt.Fprint(w, pageResponse("c1", false, node))
+	}))
+	defer srv.Close()
+
+	api := Wrap(newTestClient(srv))
+	_, err := api.ClusterUpgrade(ctx, wantID)
+	if err == nil {
+		t.Fatal("expected ErrNotFound")
+	}
+	if !errors.Is(err, graphql.ErrNotFound) {
+		t.Errorf("error should wrap ErrNotFound: %v", err)
+	}
+}
+
+func TestClusterUpgradeFound(t *testing.T) {
+	ctx, cancel := context.WithCancelCause(context.Background())
+	defer assert.Context(t, ctx, cancel)
+
+	wantID := uuid.MustParse("11111111-1111-1111-1111-111111111111")
+	srv := httptest.NewServer(handler.GraphQL(func(w http.ResponseWriter, req *http.Request) {
+		node := fmt.Sprintf(`{"id":%q,"name":"cluster-a","cdmUpgradeInfo":{"clusterUuid":%q,"version":"9.2.1"}}`, wantID, wantID)
+		fmt.Fprint(w, pageResponse("c1", false, node))
+	}))
+	defer srv.Close()
+
+	api := Wrap(newTestClient(srv))
+	got, err := api.ClusterUpgrade(ctx, wantID)
+	if err != nil {
+		t.Fatalf("ClusterUpgrade: %v", err)
+	}
+	if got.ID != wantID {
+		t.Errorf("ID: got %v, want %v", got.ID, wantID)
+	}
+	if got.CDMInfo == nil || got.CDMInfo.Version != "9.2.1" {
+		t.Errorf("CDMInfo: got %+v", got.CDMInfo)
+	}
+}

--- a/pkg/polaris/graphql/cluster/cluster_types.go
+++ b/pkg/polaris/graphql/cluster/cluster_types.go
@@ -7,10 +7,11 @@ type Timezone string
 type Product string
 
 const (
-	CDM          Product = "CDM"
-	CLOUD_DIRECT Product = "CLOUD_DIRECT"
-	DATOS        Product = "DATOS"
-	POLARIS      Product = "POLARIS"
+	CDM            Product = "CDM"
+	CLOUD_DIRECT   Product = "CLOUD_DIRECT"
+	DATOS          Product = "DATOS"
+	POLARIS        Product = "POLARIS"
+	RSCP_APPLIANCE Product = "RSCP_APPLIANCE"
 )
 
 // ProductType represents the valid cluster product types.

--- a/pkg/polaris/graphql/cluster/queries.go
+++ b/pkg/polaris/graphql/cluster/queries.go
@@ -187,6 +187,128 @@ var clusterSettingsQuery = `query SdkGolangClusterSettings($id: UUID!) {
   }
 }`
 
+// clusterWithUpgradesInfo GraphQL query
+var clusterWithUpgradesInfoQuery = `query SdkGolangClusterWithUpgradesInfo(
+  $first: Int
+  $after: String
+  $last: Int
+  $before: String
+  $sortOrder: SortOrder
+  $sortBy: UpgradeInfoSortByEnum
+  $clusterLocation: [String!]
+  $connectionState: [ClusterStatus!]
+  $downloadedVersion: [String!]
+  $eosStatus: [ClusterEosStatus!]
+  $id: [UUID!]
+  $installedVersion: [String!]
+  $minSoftwareVersion: String
+  $name: [String!]
+  $prechecksStatus: [PrechecksStatusTypeEnum!]
+  $productType: [ClusterProductEnum!]
+  $registrationTimeGt: DateTime
+  $registrationTimeLt: DateTime
+  $type: [ClusterTypeEnum!]
+  $upgradeJobStatus: [ClusterJobStatusTypeEnum!]
+  $upgradeScheduled: Boolean
+  $upgradeStatusCategory: [String!]
+  $versionStatus: [VersionStatus!]
+) {
+  result: clusterWithUpgradesInfo(
+    first: $first
+    after: $after
+    last: $last
+    before: $before
+    sortOrder: $sortOrder
+    sortBy: $sortBy
+    upgradeFilter: {
+      clusterLocation: $clusterLocation
+      connectionState: $connectionState
+      downloadedVersion: $downloadedVersion
+      eosStatus: $eosStatus
+      id: $id
+      installedVersion: $installedVersion
+      minSoftwareVersion: $minSoftwareVersion
+      name: $name
+      prechecksStatus: $prechecksStatus
+      productType: $productType
+      registrationTime_gt: $registrationTimeGt
+      registrationTime_lt: $registrationTimeLt
+      type: $type
+      upgradeJobStatus: $upgradeJobStatus
+      upgradeScheduled: $upgradeScheduled
+      upgradeStatusCategory: $upgradeStatusCategory
+      versionStatus: $versionStatus
+    }
+  ) {
+    edges {
+      cursor
+      node {
+        id
+        name
+        cdmUpgradeInfo {
+          clusterUuid
+          version
+          versionStatus
+          clusterJobStatus
+          clusterStatus {
+            message
+            status
+            statusInfo {
+              completedNodes
+              currentNode
+            }
+          }
+          currentStateProgress
+          downloadedVersion
+          fastUpgradePreferred
+          finishedStates
+          isRuSupported
+          overallProgress
+          pendingStates
+          previousVersion
+          ruUnsupportabilityReason
+          scheduleUpgradeAction
+          scheduleUpgradeAt
+          scheduleUpgradeMode
+          stateMachineStatus
+          stateMachineStatusAt
+          upgradeEndAt
+          upgradeEventSeriesId
+          upgradeStartAt
+          upgradeStatusV2 {
+            rscClusterUpgradeStatus
+            uiStatus
+            uiStatusAttributes {
+              sourceVersion
+              targetVersion
+              progress
+              errorMsg
+              upgradeMode
+            }
+          }
+          upgradeRecommendationInfo {
+            recommendation
+            nextReleaseRecommendation
+            upgradability
+          }
+          lastUpgradeDuration {
+            clusterUuid
+            fastUpgradeDuration
+            rollingUpgradeDuration
+          }
+        }
+      }
+    }
+    pageInfo {
+      startCursor
+      endCursor
+      hasPreviousPage
+      hasNextPage
+    }
+    count
+  }
+}`
+
 // removeCdmCluster GraphQL query
 var removeCdmClusterQuery = `mutation SdkGolangRemoveCdmCluster($clusterUuid: UUID!, $expireInDays: Long, $isForce: Boolean!) {
   result: removeCdmCluster(

--- a/pkg/polaris/graphql/cluster/queries/cluster_with_upgrades_info.graphql
+++ b/pkg/polaris/graphql/cluster/queries/cluster_with_upgrades_info.graphql
@@ -1,0 +1,120 @@
+query RubrikPolarisSDKRequest(
+  $first: Int
+  $after: String
+  $last: Int
+  $before: String
+  $sortOrder: SortOrder
+  $sortBy: UpgradeInfoSortByEnum
+  $clusterLocation: [String!]
+  $connectionState: [ClusterStatus!]
+  $downloadedVersion: [String!]
+  $eosStatus: [ClusterEosStatus!]
+  $id: [UUID!]
+  $installedVersion: [String!]
+  $minSoftwareVersion: String
+  $name: [String!]
+  $prechecksStatus: [PrechecksStatusTypeEnum!]
+  $productType: [ClusterProductEnum!]
+  $registrationTimeGt: DateTime
+  $registrationTimeLt: DateTime
+  $type: [ClusterTypeEnum!]
+  $upgradeJobStatus: [ClusterJobStatusTypeEnum!]
+  $upgradeScheduled: Boolean
+  $upgradeStatusCategory: [String!]
+  $versionStatus: [VersionStatus!]
+) {
+  result: clusterWithUpgradesInfo(
+    first: $first
+    after: $after
+    last: $last
+    before: $before
+    sortOrder: $sortOrder
+    sortBy: $sortBy
+    upgradeFilter: {
+      clusterLocation: $clusterLocation
+      connectionState: $connectionState
+      downloadedVersion: $downloadedVersion
+      eosStatus: $eosStatus
+      id: $id
+      installedVersion: $installedVersion
+      minSoftwareVersion: $minSoftwareVersion
+      name: $name
+      prechecksStatus: $prechecksStatus
+      productType: $productType
+      registrationTime_gt: $registrationTimeGt
+      registrationTime_lt: $registrationTimeLt
+      type: $type
+      upgradeJobStatus: $upgradeJobStatus
+      upgradeScheduled: $upgradeScheduled
+      upgradeStatusCategory: $upgradeStatusCategory
+      versionStatus: $versionStatus
+    }
+  ) {
+    edges {
+      cursor
+      node {
+        id
+        name
+        cdmUpgradeInfo {
+          clusterUuid
+          version
+          versionStatus
+          clusterJobStatus
+          clusterStatus {
+            message
+            status
+            statusInfo {
+              completedNodes
+              currentNode
+            }
+          }
+          currentStateProgress
+          downloadedVersion
+          fastUpgradePreferred
+          finishedStates
+          isRuSupported
+          overallProgress
+          pendingStates
+          previousVersion
+          ruUnsupportabilityReason
+          scheduleUpgradeAction
+          scheduleUpgradeAt
+          scheduleUpgradeMode
+          stateMachineStatus
+          stateMachineStatusAt
+          upgradeEndAt
+          upgradeEventSeriesId
+          upgradeStartAt
+          upgradeStatusV2 {
+            rscClusterUpgradeStatus
+            uiStatus
+            uiStatusAttributes {
+              sourceVersion
+              targetVersion
+              progress
+              errorMsg
+              upgradeMode
+            }
+          }
+          upgradeRecommendationInfo {
+            recommendation
+            nextReleaseRecommendation
+            upgradability
+          }
+          lastUpgradeDuration {
+            clusterUuid
+            fastUpgradeDuration
+            rollingUpgradeDuration
+          }
+        }
+      }
+    }
+    pageInfo {
+      startCursor
+      endCursor
+      hasPreviousPage
+      hasNextPage
+    }
+    count
+  }
+}

--- a/pkg/polaris/graphql/cluster/upgrade.go
+++ b/pkg/polaris/graphql/cluster/upgrade.go
@@ -24,10 +24,108 @@ import (
 	"context"
 	"encoding/json"
 	"fmt"
+	"time"
 
+	"github.com/google/uuid"
 	"github.com/rubrikinc/rubrik-polaris-sdk-for-go/pkg/polaris/graphql"
+	"github.com/rubrikinc/rubrik-polaris-sdk-for-go/pkg/polaris/graphql/core"
 	"github.com/rubrikinc/rubrik-polaris-sdk-for-go/pkg/polaris/log"
 )
+
+// UpgradeInfoPage is one page of results from clusterWithUpgradesInfo.
+type UpgradeInfoPage struct {
+	Details  []UpgradeDetails
+	PageInfo core.PageInfo
+	Count    int
+}
+
+// ClusterWithUpgradesInfo returns one page of cluster upgrade information,
+// applying the optional filter and sort and using the supplied pagination.
+func ClusterWithUpgradesInfo(ctx context.Context, gql *graphql.Client, filter *CDMInfoFilter, sortBy UpgradeInfoSortBy, page core.Pagination) (UpgradeInfoPage, error) {
+	gql.Log().Print(log.Trace)
+
+	if filter == nil {
+		filter = &CDMInfoFilter{}
+	}
+	query := clusterWithUpgradesInfoQuery
+	buf, err := gql.Request(ctx, query, struct {
+		First                 *int               `json:"first,omitempty"`
+		After                 *string            `json:"after,omitempty"`
+		Last                  *int               `json:"last,omitempty"`
+		Before                *string            `json:"before,omitempty"`
+		SortOrder             *core.SortOrder    `json:"sortOrder,omitempty"`
+		SortBy                UpgradeInfoSortBy  `json:"sortBy,omitempty"`
+		ClusterLocation       []string           `json:"clusterLocation,omitempty"`
+		ConnectionState       []Status           `json:"connectionState,omitempty"`
+		DownloadedVersion     []string           `json:"downloadedVersion,omitempty"`
+		EOSStatus             []ClusterEOSStatus `json:"eosStatus,omitempty"`
+		ID                    []uuid.UUID        `json:"id,omitempty"`
+		InstalledVersion      []string           `json:"installedVersion,omitempty"`
+		MinSoftwareVersion    string             `json:"minSoftwareVersion,omitempty"`
+		Name                  []string           `json:"name,omitempty"`
+		PrechecksStatus       []PrechecksStatus  `json:"prechecksStatus,omitempty"`
+		ProductType           []Product          `json:"productType,omitempty"`
+		RegistrationTimeGT    *time.Time         `json:"registrationTimeGt,omitzero"`
+		RegistrationTimeLT    *time.Time         `json:"registrationTimeLt,omitzero"`
+		Type                  []ProductType      `json:"type,omitempty"`
+		UpgradeJobStatus      []ClusterJobStatus `json:"upgradeJobStatus,omitempty"`
+		UpgradeScheduled      *bool              `json:"upgradeScheduled,omitempty"`
+		UpgradeStatusCategory []string           `json:"upgradeStatusCategory,omitempty"`
+		VersionStatus         []VersionStatus    `json:"versionStatus,omitempty"`
+	}{
+		First:                 page.First,
+		After:                 page.After,
+		Last:                  page.Last,
+		Before:                page.Before,
+		SortOrder:             page.SortOrder,
+		SortBy:                sortBy,
+		ClusterLocation:       filter.ClusterLocation,
+		ConnectionState:       filter.ConnectionState,
+		DownloadedVersion:     filter.DownloadedVersion,
+		EOSStatus:             filter.EOSStatus,
+		ID:                    filter.ID,
+		InstalledVersion:      filter.InstalledVersion,
+		MinSoftwareVersion:    filter.MinSoftwareVersion,
+		Name:                  filter.Name,
+		PrechecksStatus:       filter.PrechecksStatus,
+		ProductType:           filter.ProductType,
+		RegistrationTimeGT:    filter.RegistrationTimeGT,
+		RegistrationTimeLT:    filter.RegistrationTimeLT,
+		Type:                  filter.Type,
+		UpgradeJobStatus:      filter.UpgradeJobStatus,
+		UpgradeScheduled:      filter.UpgradeScheduled,
+		UpgradeStatusCategory: filter.UpgradeStatusCategory,
+		VersionStatus:         filter.VersionStatus,
+	})
+	if err != nil {
+		return UpgradeInfoPage{}, graphql.RequestError(query, err)
+	}
+
+	var payload struct {
+		Data struct {
+			Result struct {
+				Edges []struct {
+					Node UpgradeDetails `json:"node"`
+				} `json:"edges"`
+				PageInfo core.PageInfo `json:"pageInfo"`
+				Count    int           `json:"count"`
+			} `json:"result"`
+		} `json:"data"`
+	}
+	if err := json.Unmarshal(buf, &payload); err != nil {
+		return UpgradeInfoPage{}, graphql.UnmarshalError(query, err)
+	}
+
+	details := make([]UpgradeDetails, 0, len(payload.Data.Result.Edges))
+	for _, edge := range payload.Data.Result.Edges {
+		details = append(details, edge.Node)
+	}
+	return UpgradeInfoPage{
+		Details:  details,
+		PageInfo: payload.Data.Result.PageInfo,
+		Count:    payload.Data.Result.Count,
+	}, nil
+}
 
 // SelfServeRollingUpgrade returns whether self-serve rolling upgrade is
 // enabled for the account.
@@ -80,4 +178,196 @@ func SetSelfServeRollingUpgrade(ctx context.Context, gql *graphql.Client, enable
 		return graphql.ResponseError(query, fmt.Errorf("self-serve rolling upgrade not set: requested %t, got %t", enabled, payload.Data.Result.Enabled))
 	}
 	return nil
+}
+
+// UpgradeInfoSortBy represents the sort field for cluster upgrade info queries.
+type UpgradeInfoSortBy string
+
+const (
+	UpgradeInfoSortByClusterJobStatus  UpgradeInfoSortBy = "ClusterJobStatus"
+	UpgradeInfoSortByClusterLocation   UpgradeInfoSortBy = "ClusterLocation"
+	UpgradeInfoSortByClusterName       UpgradeInfoSortBy = "ClusterName"
+	UpgradeInfoSortByClusterType       UpgradeInfoSortBy = "ClusterType"
+	UpgradeInfoSortByDownloadedVersion UpgradeInfoSortBy = "DownloadedVersion"
+	UpgradeInfoSortByInstalledVersion  UpgradeInfoSortBy = "InstalledVersion"
+	UpgradeInfoSortByRegisteredAt      UpgradeInfoSortBy = "RegisteredAt"
+	UpgradeInfoSortByUpgradeType       UpgradeInfoSortBy = "UpgradeType"
+	UpgradeInfoSortByVersionStatus     UpgradeInfoSortBy = "VersionStatus"
+)
+
+// ClusterJobStatus represents the cluster upgrade job status.
+type ClusterJobStatus string
+
+const (
+	ClusterJobStatusDownloadPackageFailed   ClusterJobStatus = "DownloadPackageFailed"
+	ClusterJobStatusDownloadingPackage      ClusterJobStatus = "DownloadingPackage"
+	ClusterJobStatusFailedToInitiateUpgrade ClusterJobStatus = "FailedToInitiateUpgrade"
+	ClusterJobStatusPreCheckFailureError    ClusterJobStatus = "PreCheckFailureError"
+	ClusterJobStatusPreCheckFailureWarning  ClusterJobStatus = "PreCheckFailureWarning"
+	ClusterJobStatusReadyForDownload        ClusterJobStatus = "ReadyForDownload"
+	ClusterJobStatusReadyForUpgrade         ClusterJobStatus = "ReadyForUpgrade"
+	ClusterJobStatusResumingUpgrade         ClusterJobStatus = "ResumingUpgrade"
+	ClusterJobStatusRollbackFailed          ClusterJobStatus = "RollbackFailed"
+	ClusterJobStatusRollingBackUpgrade      ClusterJobStatus = "RollingBackUpgrade"
+	ClusterJobStatusUnknown                 ClusterJobStatus = "Unknown"
+	ClusterJobStatusUpToDate                ClusterJobStatus = "UpToDate"
+	ClusterJobStatusUpgradeFailed           ClusterJobStatus = "UpgradeFailed"
+	ClusterJobStatusUpgrading               ClusterJobStatus = "Upgrading"
+)
+
+// ClusterEOSStatus represents the end-of-support status of a cluster.
+type ClusterEOSStatus string
+
+const (
+	ClusterEOSStatusPlanUpgrade ClusterEOSStatus = "EOS_STATUS_PLAN_UPGRADE"
+	ClusterEOSStatusSupported   ClusterEOSStatus = "EOS_STATUS_SUPPORTED"
+	ClusterEOSStatusUnknown     ClusterEOSStatus = "EOS_STATUS_UNKNOWN"
+	ClusterEOSStatusUnsupported ClusterEOSStatus = "EOS_STATUS_UNSUPPORTED"
+)
+
+// PrechecksStatus represents the precheck status of a cluster.
+type PrechecksStatus string
+
+const (
+	PrechecksStatusFailureError   PrechecksStatus = "PrechecksFailureError"
+	PrechecksStatusFailureWarning PrechecksStatus = "PrechecksFailureWarning"
+	PrechecksStatusRunning        PrechecksStatus = "PrechecksRunning"
+	PrechecksStatusSuccess        PrechecksStatus = "PrechecksSuccess"
+	PrechecksStatusUnknown        PrechecksStatus = "Unknown"
+)
+
+// VersionStatus represents the version status of a cluster.
+type VersionStatus string
+
+const (
+	VersionStatusStable             VersionStatus = "STABLE"
+	VersionStatusUnknown            VersionStatus = "UNKNOWN"
+	VersionStatusUpgradeRecommended VersionStatus = "UPGRADE_RECOMMENDED"
+)
+
+// CDMInfoFilter is the filter input for clusterWithUpgradesInfo.
+type CDMInfoFilter struct {
+	ClusterLocation       []string           `json:"clusterLocation,omitempty"`
+	ConnectionState       []Status           `json:"connectionState,omitempty"`
+	DownloadedVersion     []string           `json:"downloadedVersion,omitempty"`
+	EOSStatus             []ClusterEOSStatus `json:"eosStatus,omitempty"`
+	ID                    []uuid.UUID        `json:"id,omitempty"`
+	InstalledVersion      []string           `json:"installedVersion,omitempty"`
+	MinSoftwareVersion    string             `json:"minSoftwareVersion,omitempty"`
+	Name                  []string           `json:"name,omitempty"`
+	PrechecksStatus       []PrechecksStatus  `json:"prechecksStatus,omitempty"`
+	ProductType           []Product          `json:"productType,omitempty"`
+	RegistrationTimeGT    *time.Time         `json:"registrationTime_gt,omitzero"`
+	RegistrationTimeLT    *time.Time         `json:"registrationTime_lt,omitzero"`
+	Type                  []ProductType      `json:"type,omitempty"`
+	UpgradeJobStatus      []ClusterJobStatus `json:"upgradeJobStatus,omitempty"`
+	UpgradeScheduled      *bool              `json:"upgradeScheduled,omitempty"`
+	UpgradeStatusCategory []string           `json:"upgradeStatusCategory,omitempty"`
+	VersionStatus         []VersionStatus    `json:"versionStatus,omitempty"`
+}
+
+// RSCUpgradeStatusType is the V2 enum that supersedes ClusterJobStatus for
+// reporting cluster upgrade progress. The V1 ClusterJobStatus field can lag
+// (e.g. on stub clusters), so the V2 status is preferred when available.
+type RSCUpgradeStatusType string
+
+const (
+	RSCUpgradeStatusCDMOnlyOperation         RSCUpgradeStatusType = "CDM_ONLY_OPERATION"
+	RSCUpgradeStatusDisconnected             RSCUpgradeStatusType = "DISCONNECTED"
+	RSCUpgradeStatusDownloading              RSCUpgradeStatusType = "DOWNLOADING"
+	RSCUpgradeStatusDownloadFailed           RSCUpgradeStatusType = "DOWNLOAD_FAILED"
+	RSCUpgradeStatusInitializing             RSCUpgradeStatusType = "INITIALIZING"
+	RSCUpgradeStatusPrechecking              RSCUpgradeStatusType = "PRECHECKING"
+	RSCUpgradeStatusPrecheckFailed           RSCUpgradeStatusType = "PRECHECK_FAILED"
+	RSCUpgradeStatusReadyForDownload         RSCUpgradeStatusType = "READY_FOR_DOWNLOAD"
+	RSCUpgradeStatusReadyForUpgrade          RSCUpgradeStatusType = "READY_FOR_UPGRADE"
+	RSCUpgradeStatusRollingBack              RSCUpgradeStatusType = "ROLLINGBACK"
+	RSCUpgradeStatusRollingBackFailed        RSCUpgradeStatusType = "ROLLINGBACK_FAILED"
+	RSCUpgradeStatusUnknown                  RSCUpgradeStatusType = "UNKNOWN"
+	RSCUpgradeStatusUpgradeFailed            RSCUpgradeStatusType = "UPGRADE_FAILED"
+	RSCUpgradeStatusUpgrading                RSCUpgradeStatusType = "UPGRADING"
+	RSCUpgradeStatusWaitingForOperationStart RSCUpgradeStatusType = "WAITING_FOR_OPERATION_TO_START"
+)
+
+// UIStatusAttributes is the V2 detail payload for the cluster's upgrade
+// status. Fields are nullable in the schema; empty values mean "not
+// applicable for the current state".
+type UIStatusAttributes struct {
+	SourceVersion string  `json:"sourceVersion,omitempty"`
+	TargetVersion string  `json:"targetVersion,omitempty"`
+	Progress      float64 `json:"progress"`
+	ErrorMsg      string  `json:"errorMsg,omitempty"`
+	UpgradeMode   string  `json:"upgradeMode,omitempty"`
+}
+
+// UpgradeStatusV2 is the authoritative upgrade-status payload (preferred
+// over the V1 ClusterJobStatus + DownloadedVersion fields when present).
+type UpgradeStatusV2 struct {
+	RSCClusterUpgradeStatus RSCUpgradeStatusType `json:"rscClusterUpgradeStatus"`
+	UIStatus                string               `json:"uiStatus"`
+	UIStatusAttributes      UIStatusAttributes   `json:"uiStatusAttributes"`
+}
+
+// CDMClusterStatusInfo describes the upgrade tasks state.
+type CDMClusterStatusInfo struct {
+	CompletedNodes string `json:"completedNodes,omitempty"`
+	CurrentNode    string `json:"currentNode,omitempty"`
+}
+
+// CDMClusterStatus describes the cluster upgrade status.
+type CDMClusterStatus struct {
+	Message    string                `json:"message,omitempty"`
+	Status     string                `json:"status,omitempty"`
+	StatusInfo *CDMClusterStatusInfo `json:"statusInfo,omitzero"`
+}
+
+// UpgradeRecommendationInfo describes recommended upgrade versions.
+type UpgradeRecommendationInfo struct {
+	Recommendation            string   `json:"recommendation"`
+	NextReleaseRecommendation string   `json:"nextReleaseRecommendation"`
+	Upgradability             []string `json:"upgradability"`
+}
+
+// UpgradeDuration describes the duration of the last successful upgrade.
+type UpgradeDuration struct {
+	ClusterID              uuid.UUID `json:"clusterUuid"`
+	FastUpgradeDuration    int64     `json:"fastUpgradeDuration"`
+	RollingUpgradeDuration int64     `json:"rollingUpgradeDuration"`
+}
+
+// CDMInfo describes the upgrade state of a CDM cluster.
+type CDMInfo struct {
+	ClusterID                 uuid.UUID                  `json:"clusterUuid"`
+	Version                   string                     `json:"version"`
+	VersionStatus             VersionStatus              `json:"versionStatus,omitempty"`
+	ClusterJobStatus          ClusterJobStatus           `json:"clusterJobStatus,omitempty"`
+	ClusterStatus             *CDMClusterStatus          `json:"clusterStatus,omitzero"`
+	CurrentStateProgress      float64                    `json:"currentStateProgress"`
+	DownloadedVersion         string                     `json:"downloadedVersion,omitempty"`
+	FastUpgradePreferred      bool                       `json:"fastUpgradePreferred,omitempty"`
+	FinishedStates            string                     `json:"finishedStates,omitempty"`
+	IsRUSupported             bool                       `json:"isRuSupported,omitempty"`
+	OverallProgress           float64                    `json:"overallProgress"`
+	PendingStates             string                     `json:"pendingStates,omitempty"`
+	PreviousVersion           string                     `json:"previousVersion,omitempty"`
+	RUUnsupportabilityReason  string                     `json:"ruUnsupportabilityReason,omitempty"`
+	ScheduleUpgradeAction     string                     `json:"scheduleUpgradeAction,omitempty"`
+	ScheduleUpgradeAt         *time.Time                 `json:"scheduleUpgradeAt,omitzero"`
+	ScheduleUpgradeMode       string                     `json:"scheduleUpgradeMode,omitempty"`
+	StateMachineStatus        string                     `json:"stateMachineStatus,omitempty"`
+	StateMachineStatusAt      *time.Time                 `json:"stateMachineStatusAt,omitzero"`
+	UpgradeEndAt              *time.Time                 `json:"upgradeEndAt,omitzero"`
+	UpgradeEventSeriesID      string                     `json:"upgradeEventSeriesId,omitempty"`
+	UpgradeStartAt            *time.Time                 `json:"upgradeStartAt,omitzero"`
+	UpgradeStatusV2           *UpgradeStatusV2           `json:"upgradeStatusV2,omitzero"`
+	UpgradeRecommendationInfo *UpgradeRecommendationInfo `json:"upgradeRecommendationInfo,omitzero"`
+	LastUpgradeDuration       *UpgradeDuration           `json:"lastUpgradeDuration,omitzero"`
+}
+
+// UpgradeDetails bundles the cluster identity with its upgrade info, as
+// returned by clusterWithUpgradesInfo.
+type UpgradeDetails struct {
+	ID      uuid.UUID `json:"id"`
+	Name    string    `json:"name"`
+	CDMInfo *CDMInfo  `json:"cdmUpgradeInfo,omitzero"`
 }

--- a/pkg/polaris/graphql/cluster/upgrade_test.go
+++ b/pkg/polaris/graphql/cluster/upgrade_test.go
@@ -1,0 +1,201 @@
+// Copyright 2026 Rubrik, Inc.
+//
+// Permission is hereby granted, free of charge, to any person obtaining a copy
+// of this software and associated documentation files (the "Software"), to
+// deal in the Software without restriction, including without limitation the
+// rights to use, copy, modify, merge, publish, distribute, sublicense, and/or
+// sell copies of the Software, and to permit persons to whom the Software is
+// furnished to do so, subject to the following conditions:
+//
+// The above copyright notice and this permission notice shall be included in
+// all copies or substantial portions of the Software.
+//
+// THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+// IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+// FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+// AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+// LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING
+// FROM, OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER
+// DEALINGS IN THE SOFTWARE.
+
+package cluster
+
+import (
+	"context"
+	"encoding/json"
+	"fmt"
+	"net/http"
+	"net/http/httptest"
+	"slices"
+	"testing"
+	"time"
+
+	"github.com/google/uuid"
+	"github.com/rubrikinc/rubrik-polaris-sdk-for-go/internal/assert"
+	"github.com/rubrikinc/rubrik-polaris-sdk-for-go/internal/handler"
+	"github.com/rubrikinc/rubrik-polaris-sdk-for-go/pkg/polaris/graphql"
+	"github.com/rubrikinc/rubrik-polaris-sdk-for-go/pkg/polaris/graphql/core"
+)
+
+func TestCDMInfoFilterOmitsEmptyFields(t *testing.T) {
+	enabled := true
+	id := uuid.MustParse("aaaaaaaa-bbbb-cccc-dddd-eeeeeeeeeeee")
+	in := CDMInfoFilter{
+		ID:               []uuid.UUID{id},
+		UpgradeScheduled: &enabled,
+	}
+	buf, err := json.Marshal(in)
+	if err != nil {
+		t.Fatalf("marshal: %v", err)
+	}
+	var got map[string]any
+	if err := json.Unmarshal(buf, &got); err != nil {
+		t.Fatalf("unmarshal: %v", err)
+	}
+	want := []string{"id", "upgradeScheduled"}
+	keys := make([]string, 0, len(got))
+	for k := range got {
+		keys = append(keys, k)
+	}
+	slices.Sort(keys)
+	if !slices.Equal(keys, want) {
+		t.Fatalf("unexpected keys: got %v, want %v", keys, want)
+	}
+	if ids, _ := got["id"].([]any); len(ids) != 1 || ids[0] != id.String() {
+		t.Fatalf("unexpected id: %v", got["id"])
+	}
+	if got["upgradeScheduled"] != true {
+		t.Fatalf("unexpected upgradeScheduled: %v", got["upgradeScheduled"])
+	}
+}
+
+func TestCDMInfoUnmarshal(t *testing.T) {
+	src := `{
+        "clusterUuid": "11111111-2222-3333-4444-555555555555",
+        "version": "9.2.1",
+        "versionStatus": "UpToDate",
+        "clusterJobStatus": "Idle",
+        "clusterStatus": {"message": "Healthy", "status": "READY"},
+        "currentStateProgress": 0.5,
+        "downloadedVersion": "9.2.2",
+        "fastUpgradePreferred": false,
+        "isRuSupported": true,
+        "overallProgress": 0.75,
+        "scheduleUpgradeAt": "2026-06-01T01:02:03Z",
+        "upgradeRecommendationInfo": {
+            "recommendation": "9.2.2",
+            "nextReleaseRecommendation": "9.3.0",
+            "upgradability": ["9.2.2","9.3.0"]
+        },
+        "lastUpgradeDuration": {"clusterUuid": "11111111-2222-3333-4444-555555555555", "fastUpgradeDuration": 600, "rollingUpgradeDuration": 1800}
+    }`
+	var got CDMInfo
+	if err := json.Unmarshal([]byte(src), &got); err != nil {
+		t.Fatalf("unmarshal: %v", err)
+	}
+	if got.Version != "9.2.1" || got.VersionStatus != "UpToDate" || got.DownloadedVersion != "9.2.2" {
+		t.Fatalf("unexpected basic fields: %+v", got)
+	}
+	if !got.IsRUSupported {
+		t.Fatalf("expected IsRUSupported true")
+	}
+	if got.ScheduleUpgradeAt == nil || !got.ScheduleUpgradeAt.Equal(time.Date(2026, 6, 1, 1, 2, 3, 0, time.UTC)) {
+		t.Fatalf("unexpected scheduleUpgradeAt: %+v", got.ScheduleUpgradeAt)
+	}
+	if got.UpgradeRecommendationInfo == nil || got.UpgradeRecommendationInfo.Recommendation != "9.2.2" {
+		t.Fatalf("unexpected recommendation: %+v", got.UpgradeRecommendationInfo)
+	}
+	if got.LastUpgradeDuration == nil || got.LastUpgradeDuration.FastUpgradeDuration != 600 {
+		t.Fatalf("unexpected lastUpgradeDuration: %+v", got.LastUpgradeDuration)
+	}
+}
+
+// TestClusterWithUpgradesInfoExtrapolatesFilter asserts that the filter
+// struct fields are sent as individual top-level variables in the request
+// body (i.e. that the call extrapolates the input rather than nesting it).
+func TestClusterWithUpgradesInfoExtrapolatesFilter(t *testing.T) {
+	ctx, cancel := context.WithCancelCause(context.Background())
+	defer assert.Context(t, ctx, cancel)
+
+	clusterID := uuid.MustParse("11111111-2222-3333-4444-555555555555")
+	srv := httptest.NewServer(handler.GraphQL(func(w http.ResponseWriter, req *http.Request) {
+		var body struct {
+			Variables map[string]json.RawMessage `json:"variables"`
+		}
+		if err := json.NewDecoder(req.Body).Decode(&body); err != nil {
+			http.Error(w, err.Error(), http.StatusBadRequest)
+			return
+		}
+		if _, ok := body.Variables["upgradeFilter"]; ok {
+			http.Error(w, "filter must be extrapolated, not passed as composite", http.StatusBadRequest)
+			return
+		}
+		for _, key := range []string{"id", "first"} {
+			if _, ok := body.Variables[key]; !ok {
+				http.Error(w, fmt.Sprintf("missing variable %q", key), http.StatusBadRequest)
+				return
+			}
+		}
+		fmt.Fprintf(w, `{
+            "data": {
+                "result": {
+                    "edges": [{
+                        "cursor": "c1",
+                        "node": {
+                            "id": "%s",
+                            "name": "cluster-a",
+                            "cdmUpgradeInfo": {
+                                "clusterUuid": "%s",
+                                "version": "9.2.1"
+                            }
+                        }
+                    }],
+                    "pageInfo": {"startCursor": "c1", "endCursor": "c1", "hasPreviousPage": false, "hasNextPage": false},
+                    "count": 1
+                }
+            }
+        }`, clusterID, clusterID)
+	}))
+	defer srv.Close()
+
+	pageSize := 10
+	got, err := ClusterWithUpgradesInfo(ctx, graphql.NewTestClient(srv),
+		&CDMInfoFilter{ID: []uuid.UUID{clusterID}},
+		UpgradeInfoSortByClusterName,
+		core.Pagination{First: &pageSize},
+	)
+	if err != nil {
+		t.Fatalf("ClusterWithUpgradesInfo: %v", err)
+	}
+	if len(got.Details) != 1 || got.Details[0].ID != clusterID {
+		t.Fatalf("unexpected details: %+v", got.Details)
+	}
+	if got.Details[0].CDMInfo == nil || got.Details[0].CDMInfo.Version != "9.2.1" {
+		t.Fatalf("unexpected CDMInfo: %+v", got.Details[0].CDMInfo)
+	}
+	if got.Count != 1 {
+		t.Fatalf("unexpected count: %d", got.Count)
+	}
+	if got.PageInfo.HasNextPage {
+		t.Fatalf("expected HasNextPage false")
+	}
+}
+
+// TestClusterWithUpgradesInfoNilFilter ensures a nil filter is accepted.
+func TestClusterWithUpgradesInfoNilFilter(t *testing.T) {
+	ctx, cancel := context.WithCancelCause(context.Background())
+	defer assert.Context(t, ctx, cancel)
+
+	srv := httptest.NewServer(handler.GraphQL(func(w http.ResponseWriter, req *http.Request) {
+		fmt.Fprint(w, `{"data":{"result":{"edges":[],"pageInfo":{"hasNextPage":false},"count":0}}}`)
+	}))
+	defer srv.Close()
+
+	got, err := ClusterWithUpgradesInfo(ctx, graphql.NewTestClient(srv), nil, "", core.Pagination{})
+	if err != nil {
+		t.Fatalf("ClusterWithUpgradesInfo: %v", err)
+	}
+	if len(got.Details) != 0 {
+		t.Fatalf("expected 0 details, got %d", len(got.Details))
+	}
+}


### PR DESCRIPTION
# Description

Add ListClusterUpgrades and ClusterUpgrade APIs.
Wraps the clusterWithUpgradesInfo GraphQL endpoint with a paginating ListClusterUpgrades helper and a single-cluster ClusterUpgrade lookup that returns graphql.ErrNotFound when the cluster is not registered. Adds the RSCP_APPLIANCE Product constant.

## How Has This Been Tested?

Manually.

## Types of changes

What types of changes does your code introduce? Put an `x` in all the boxes that apply:
- [ ] Bug fix (non-breaking change which fixes an issue)
- [x] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)
- [ ] Other (please describe in the Description above)

## Checklist:

Go over all the following points, and put an `x` in all the boxes that apply. If you're unsure about any of these, don't hesitate to ask. We're here to help!
- [x] My code follows the code style of this project.
- [ ] My change requires a change to the documentation.
- [ ] I have updated the documentation accordingly.
- [ ] I have updated the CHANGELOG file accordingly for the version that this merge modifies.
- [ ] I have added tests to cover my changes.
- [x] All new and existing tests passed.
