### PR TITLE
Add MultiHopUpgradePath to retrieve the CDM upgrade version sequence

### DIFF
--- a/pkg/polaris/graphql/cluster/queries.go
+++ b/pkg/polaris/graphql/cluster/queries.go
@@ -339,6 +339,23 @@ var clusterWithUpgradesInfoQuery = `query SdkGolangClusterWithUpgradesInfo(
   }
 }`
 
+// multiHopUpgradePath GraphQL query
+var multiHopUpgradePathQuery = `query SdkGolangMultiHopUpgradePath(
+  $clusterUuid: UUID!
+  $sourceVersion: String
+  $targetVersion: String!
+  $shouldIncludeFullVersionName: Boolean
+) {
+  result: multiHopUpgradePath(
+    clusterUuid: $clusterUuid
+    sourceVersion: $sourceVersion
+    targetVersion: $targetVersion
+    shouldIncludeFullVersionName: $shouldIncludeFullVersionName
+  ) {
+    versionPath
+  }
+}`
+
 // removeCdmCluster GraphQL query
 var removeCdmClusterQuery = `mutation SdkGolangRemoveCdmCluster($clusterUuid: UUID!, $expireInDays: Long, $isForce: Boolean!) {
   result: removeCdmCluster(

--- a/pkg/polaris/graphql/cluster/queries/multi_hop_upgrade_path.graphql
+++ b/pkg/polaris/graphql/cluster/queries/multi_hop_upgrade_path.graphql
@@ -1,0 +1,15 @@
+query RubrikPolarisSDKRequest(
+  $clusterUuid: UUID!
+  $sourceVersion: String
+  $targetVersion: String!
+  $shouldIncludeFullVersionName: Boolean
+) {
+  result: multiHopUpgradePath(
+    clusterUuid: $clusterUuid
+    sourceVersion: $sourceVersion
+    targetVersion: $targetVersion
+    shouldIncludeFullVersionName: $shouldIncludeFullVersionName
+  ) {
+    versionPath
+  }
+}

--- a/pkg/polaris/graphql/cluster/upgrade.go
+++ b/pkg/polaris/graphql/cluster/upgrade.go
@@ -200,6 +200,47 @@ func ListUpgrades(ctx context.Context, gql *graphql.Client, clusters []uuid.UUID
 	return payload.Data.Result.ReleaseDetails, nil
 }
 
+// MultiHopUpgradePath returns the ordered sequence of CDM versions required
+// to upgrade the cluster from sourceVersion to targetVersion (both inclusive).
+// If sourceVersion is empty, the server uses the cluster's currently installed
+// version. When fullVersionName is true, each hop is returned as the full
+// release name including patch and build number.
+func MultiHopUpgradePath(ctx context.Context, gql *graphql.Client, clusterID uuid.UUID, sourceVersion, targetVersion string, fullVersionName bool) ([]string, error) {
+	gql.Log().Print(log.Trace)
+
+	if targetVersion == "" {
+		return nil, fmt.Errorf("target version is required")
+	}
+
+	query := multiHopUpgradePathQuery
+	buf, err := gql.Request(ctx, query, struct {
+		ClusterUUID                  uuid.UUID `json:"clusterUuid"`
+		SourceVersion                string    `json:"sourceVersion,omitempty"`
+		TargetVersion                string    `json:"targetVersion"`
+		ShouldIncludeFullVersionName bool      `json:"shouldIncludeFullVersionName"`
+	}{
+		ClusterUUID:                  clusterID,
+		SourceVersion:                sourceVersion,
+		TargetVersion:                targetVersion,
+		ShouldIncludeFullVersionName: fullVersionName,
+	})
+	if err != nil {
+		return nil, graphql.RequestError(query, err)
+	}
+
+	var payload struct {
+		Data struct {
+			Result struct {
+				VersionPath []string `json:"versionPath"`
+			} `json:"result"`
+		} `json:"data"`
+	}
+	if err := json.Unmarshal(buf, &payload); err != nil {
+		return nil, graphql.UnmarshalError(query, err)
+	}
+	return payload.Data.Result.VersionPath, nil
+}
+
 // SelfServeRollingUpgrade returns whether self-serve rolling upgrade is
 // enabled for the account.
 func SelfServeRollingUpgrade(ctx context.Context, gql *graphql.Client) (bool, error) {


### PR DESCRIPTION
# Description

This change adds MultiHopUpgradePath to retrieve the CDM upgrade version sequence.

## Motivation and Context

CDM clusters often can't jump directly from their current version to a target version.
This API returns the ordered chain of intermediate releases (hops) that must be
installed along the way so that callers (e.g. terraform provider) can execute multi-step
upgrades.

## How Has This Been Tested?

Manually with both mocked and real CDM clusters.

## Types of changes

What types of changes does your code introduce? Put an `x` in all the boxes that apply:
- [ ] Bug fix (non-breaking change which fixes an issue)
- [x] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)
- [ ] Other (please describe in the Description above)

## Checklist:

Go over all the following points, and put an `x` in all the boxes that apply. If you're unsure about any of these, don't hesitate to ask. We're here to help!
- [x] My code follows the code style of this project.
- [ ] My change requires a change to the documentation.
- [ ] I have updated the documentation accordingly.
- [ ] I have updated the CHANGELOG file accordingly for the version that this merge modifies.
- [ ] I have added tests to cover my changes.
- [x] All new and existing tests passed.
