### PR TITLE
Add SetUpgradeType to set the fast/rolling upgrade preference

### DIFF
--- a/pkg/polaris/cluster/upgrade.go
+++ b/pkg/polaris/cluster/upgrade.go
@@ -104,3 +104,16 @@ func (a API) SetSelfServeRollingUpgrade(ctx context.Context, enabled bool) error
 	}
 	return nil
 }
+
+// SetUpgradeType sets the upgrade type (fast or rolling) for the specified
+// cluster. The returned reply carries the server-side status code and message;
+// callers should inspect Code for operational outcomes.
+func (a API) SetUpgradeType(ctx context.Context, clusterID uuid.UUID, upgradeType gqlcluster.UpgradeType) (gqlcluster.SetUpgradeTypeReply, error) {
+	a.log.Print(log.Trace)
+
+	reply, err := gqlcluster.SetUpgradeType(ctx, a.client.GQL, clusterID, upgradeType)
+	if err != nil {
+		return gqlcluster.SetUpgradeTypeReply{}, fmt.Errorf("failed to set cluster upgrade type: %s", err)
+	}
+	return reply, nil
+}

--- a/pkg/polaris/graphql/cluster/queries.go
+++ b/pkg/polaris/graphql/cluster/queries.go
@@ -381,6 +381,18 @@ var setSelfServeRollingUpgradeQuery = `mutation SdkGolangSetSelfServeRollingUpgr
   }
 }`
 
+// setUpgradeType GraphQL query
+var setUpgradeTypeQuery = `mutation SdkGolangSetUpgradeType($clusterUuid: UUID!, $upgradeType: UpgradeType!) {
+  result: setUpgradeType(input: {
+    clusterUuid: $clusterUuid,
+    upgradeType: $upgradeType,
+  }) {
+    code
+    excepshuns
+    message
+  }
+}`
+
 // slaSourceClusters GraphQL query
 var slaSourceClustersQuery = `query SdkGolangSlaSourceClusters(
   $after: String

--- a/pkg/polaris/graphql/cluster/queries/set_upgrade_type.graphql
+++ b/pkg/polaris/graphql/cluster/queries/set_upgrade_type.graphql
@@ -1,0 +1,10 @@
+mutation RubrikPolarisSDKRequest($clusterUuid: UUID!, $upgradeType: UpgradeType!) {
+  result: setUpgradeType(input: {
+    clusterUuid: $clusterUuid,
+    upgradeType: $upgradeType,
+  }) {
+    code
+    excepshuns
+    message
+  }
+}

--- a/pkg/polaris/graphql/cluster/upgrade.go
+++ b/pkg/polaris/graphql/cluster/upgrade.go
@@ -294,6 +294,50 @@ func SetSelfServeRollingUpgrade(ctx context.Context, gql *graphql.Client, enable
 	return nil
 }
 
+// UpgradeType represents the per-cluster upgrade type preference.
+type UpgradeType string
+
+const (
+	UpgradeTypeFast    UpgradeType = "FAST"
+	UpgradeTypeRolling UpgradeType = "ROLLING"
+)
+
+// SetUpgradeTypeReply is returned by setUpgradeType. The JSON tag for
+// Exceptions preserves the schema-level typo ("excepshuns").
+type SetUpgradeTypeReply struct {
+	Code       string `json:"code"`
+	Exceptions string `json:"excepshuns"`
+	Message    string `json:"message"`
+}
+
+// SetUpgradeType sets the upgrade type (fast or rolling) for the specified
+// cluster.
+func SetUpgradeType(ctx context.Context, gql *graphql.Client, clusterID uuid.UUID, upgradeType UpgradeType) (SetUpgradeTypeReply, error) {
+	gql.Log().Print(log.Trace)
+
+	query := setUpgradeTypeQuery
+	buf, err := gql.Request(ctx, query, struct {
+		ClusterUUID uuid.UUID   `json:"clusterUuid"`
+		UpgradeType UpgradeType `json:"upgradeType"`
+	}{
+		ClusterUUID: clusterID,
+		UpgradeType: upgradeType,
+	})
+	if err != nil {
+		return SetUpgradeTypeReply{}, graphql.RequestError(query, err)
+	}
+
+	var payload struct {
+		Data struct {
+			Result SetUpgradeTypeReply `json:"result"`
+		} `json:"data"`
+	}
+	if err := json.Unmarshal(buf, &payload); err != nil {
+		return SetUpgradeTypeReply{}, graphql.UnmarshalError(query, err)
+	}
+	return payload.Data.Result, nil
+}
+
 // UpgradeInfoSortBy represents the sort field for cluster upgrade info queries.
 type UpgradeInfoSortBy string
 


### PR DESCRIPTION
# Description

Add SetUpgradeType to set the fast/rolling upgrade preference
Wraps the setUpgradeType mutation with a low-level SetUpgradeType GraphQL function and a high-level cluster.API.SetUpgradeType wrapper. Also adds the UpgradeType enum (FAST, ROLLING).

## How Has This Been Tested?

Manually toggling a real cluster upgrade preference.

## Types of changes

What types of changes does your code introduce? Put an `x` in all the boxes that apply:
- [ ] Bug fix (non-breaking change which fixes an issue)
- [x] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)
- [ ] Other (please describe in the Description above)

## Checklist:

Go over all the following points, and put an `x` in all the boxes that apply. If you're unsure about any of these, don't hesitate to ask. We're here to help!
- [x] My code follows the code style of this project.
- [ ] My change requires a change to the documentation.
- [ ] I have updated the documentation accordingly.
- [ ] I have updated the CHANGELOG file accordingly for the version that this merge modifies.
- [ ] I have added tests to cover my changes.
- [x] All new and existing tests passed.
