### PR TITLE
Add UpgradeStatus for real-time upgrade state

### DIFF
--- a/pkg/polaris/cluster/upgrade.go
+++ b/pkg/polaris/cluster/upgrade.go
@@ -117,3 +117,16 @@ func (a API) SetUpgradeType(ctx context.Context, clusterID uuid.UUID, upgradeTyp
 	}
 	return reply, nil
 }
+
+// UpgradeStatus returns the cluster's real-time upgrade state via a live read
+// from the upgrade service. Prefer this over ClusterUpgrade when authoritative
+// state is required.
+func (a API) UpgradeStatus(ctx context.Context, clusterID uuid.UUID) (gqlcluster.UpgradeState, error) {
+	a.log.Print(log.Trace)
+
+	state, err := gqlcluster.UpgradeStatus(ctx, a.client.GQL, clusterID)
+	if err != nil {
+		return "", fmt.Errorf("failed to read upgrade status: %s", err)
+	}
+	return state, nil
+}

--- a/pkg/polaris/graphql/cluster/queries.go
+++ b/pkg/polaris/graphql/cluster/queries.go
@@ -493,6 +493,13 @@ var updateCusterDnsAndSearchDomainsQuery = `mutation SdkGolangUpdateCusterDnsAnd
   }
 }`
 
+// upgradeStatus GraphQL query
+var upgradeStatusQuery = `query SdkGolangUpgradeStatus($clusterUuid: UUID!) {
+  result: upgradeStatus(clusterUuid: $clusterUuid) {
+    currentStateName
+  }
+}`
+
 // verifySlaWithReplicationToCluster GraphQL query
 var verifySlaWithReplicationToClusterQuery = `query SdkGolangVerifySlaWithReplicationToCluster($clusterUuid: UUID!, $includeArchived: Boolean!) {
   result: verifySlaWithReplicationToCluster(

--- a/pkg/polaris/graphql/cluster/queries/upgrade_status.graphql
+++ b/pkg/polaris/graphql/cluster/queries/upgrade_status.graphql
@@ -1,0 +1,5 @@
+query RubrikPolarisSDKRequest($clusterUuid: UUID!) {
+  result: upgradeStatus(clusterUuid: $clusterUuid) {
+    currentStateName
+  }
+}

--- a/pkg/polaris/graphql/cluster/upgrade.go
+++ b/pkg/polaris/graphql/cluster/upgrade.go
@@ -338,6 +338,72 @@ func SetUpgradeType(ctx context.Context, gql *graphql.Client, clusterID uuid.UUI
 	return payload.Data.Result, nil
 }
 
+// UpgradeState is the cluster's current upgrade-state-machine state, as
+// reported by the upgradeStatus query. The set below covers every value the
+// upgrade service is known to emit; new entries may be added by the server
+// before the SDK is updated, so callers comparing against an unknown value
+// should fall through gracefully.
+type UpgradeState string
+
+const (
+	UpgradeStateIdle              UpgradeState = "IDLE"
+	UpgradeStateAcquiring         UpgradeState = "ACQUIRING"
+	UpgradeStateDeploying         UpgradeState = "DEPLOYING"
+	UpgradeStatePrechecking       UpgradeState = "PRECHECKING"
+	UpgradeStateUpgrading         UpgradeState = "UPGRADING"
+	UpgradeStateError             UpgradeState = "ERROR"
+	UpgradeStateCopying           UpgradeState = "COPYING"
+	UpgradeStateVerifying         UpgradeState = "VERIFYING"
+	UpgradeStateUntaring          UpgradeState = "UNTARING"
+	UpgradeStatePreparing         UpgradeState = "PREPARING"
+	UpgradeStateRestarting        UpgradeState = "RESTARTING"
+	UpgradeStateImaging           UpgradeState = "IMAGING"
+	UpgradeStateConfiguring       UpgradeState = "CONFIGURING"
+	UpgradeStateMigrating         UpgradeState = "MIGRATING"
+	UpgradeStateRollingBack       UpgradeState = "ROLLING_BACK"
+	UpgradeStateStaged            UpgradeState = "STAGED"
+	UpgradeStateRUPrecheckLock    UpgradeState = "RU_PRECHECK_LOCK"
+	UpgradeStateRUCRDBUpgrade     UpgradeState = "RU_CRDB_UPGRADE"
+	UpgradeStateRUMetadataUpgrade UpgradeState = "RU_METADATA_UPGRADE"
+	UpgradeStateRollingUpgrade    UpgradeState = "ROLLING_UPGRADE"
+	UpgradeStateRUClusterWrapup   UpgradeState = "RU_CLUSTER_WRAPUP"
+	UpgradeStateRUIdle            UpgradeState = "RU_IDLE"
+	UpgradeStateRUPrecheck        UpgradeState = "RU_PRECHECK"
+	UpgradeStateRUPreparing       UpgradeState = "RU_PREPARING"
+	UpgradeStateRUConfiguring     UpgradeState = "RU_CONFIGURING"
+	UpgradeStateRUMigrating       UpgradeState = "RU_MIGRATING"
+	UpgradeStateRURestarting      UpgradeState = "RU_RESTARTING"
+	UpgradeStateRUDone            UpgradeState = "RU_DONE"
+	UpgradeStateUnknown           UpgradeState = "UNKNOWN"
+)
+
+// UpgradeStatus returns the cluster's real-time upgrade state via a live read
+// from the upgrade service, bypassing the aggregated UpgradeStatusV2 view in
+// ClusterUpgrade which can lag by tracker-poll intervals.
+func UpgradeStatus(ctx context.Context, gql *graphql.Client, clusterID uuid.UUID) (UpgradeState, error) {
+	gql.Log().Print(log.Trace)
+
+	query := upgradeStatusQuery
+	buf, err := gql.Request(ctx, query, struct {
+		ClusterUUID uuid.UUID `json:"clusterUuid"`
+	}{ClusterUUID: clusterID})
+	if err != nil {
+		return "", graphql.RequestError(query, err)
+	}
+
+	var payload struct {
+		Data struct {
+			Result struct {
+				CurrentStateName UpgradeState `json:"currentStateName"`
+			} `json:"result"`
+		} `json:"data"`
+	}
+	if err := json.Unmarshal(buf, &payload); err != nil {
+		return "", graphql.UnmarshalError(query, err)
+	}
+	return payload.Data.Result.CurrentStateName, nil
+}
+
 // UpgradeInfoSortBy represents the sort field for cluster upgrade info queries.
 type UpgradeInfoSortBy string
 


### PR DESCRIPTION
# Description

Add UpgradeStatus for real-time upgrade state. Wraps the upgradeStatus query, which is a live read from the upgrade service that bypasses the aggregated UpgradeStatusV2 view in ClusterUpgrade (the aggregate is fed by a periodic tracker and lags behind cluster reality).

## Motivation and Context

This is required by, for example, the terraform provider as it needs an authoritative state to handle transitions correctly.

## How Has This Been Tested?

Manually against a real CDM cluster.

## Types of changes

What types of changes does your code introduce? Put an `x` in all the boxes that apply:
- [ ] Bug fix (non-breaking change which fixes an issue)
- [x] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)
- [ ] Other (please describe in the Description above)

## Checklist:

Go over all the following points, and put an `x` in all the boxes that apply. If you're unsure about any of these, don't hesitate to ask. We're here to help!
- [x] My code follows the code style of this project.
- [ ] My change requires a change to the documentation.
- [ ] I have updated the documentation accordingly.
- [ ] I have updated the CHANGELOG file accordingly for the version that this merge modifies.
- [ ] I have added tests to cover my changes.
- [x] All new and existing tests passed.
