### PR TITLE
Add Cluster Upgrade Download API

### DIFF
--- a/pkg/polaris/cluster/upgrade.go
+++ b/pkg/polaris/cluster/upgrade.go
@@ -23,6 +23,7 @@ package cluster
 import (
 	"context"
 	"fmt"
+	"time"
 
 	"github.com/google/uuid"
 	"github.com/rubrikinc/rubrik-polaris-sdk-for-go/pkg/polaris/graphql"
@@ -129,4 +130,134 @@ func (a API) UpgradeStatus(ctx context.Context, clusterID uuid.UUID) (gqlcluster
 		return "", fmt.Errorf("failed to read upgrade status: %s", err)
 	}
 	return state, nil
+}
+
+// upgradePollInitialDelay is the first sleep between WaitForDownload polls.
+var upgradePollInitialDelay = 15 * time.Second
+
+// upgradePollMaxDelay caps the exponential backoff between WaitForDownload
+// polls.
+var upgradePollMaxDelay = 60 * time.Second
+
+// DownloadPackage starts a download of the package at packageURL onto the
+// specified cluster. The server parses the version from the package filename,
+// which must follow the `rubrik-image-<version>.zip` convention. Returns the
+// job ID; poll WaitForDownload to block until the package is staged.
+func (a API) DownloadPackage(ctx context.Context, clusterID uuid.UUID, packageURL, md5checksum string) (string, error) {
+	a.log.Print(log.Trace)
+
+	jobID, err := gqlcluster.StartDownloadPackage(ctx, a.client.GQL, clusterID, packageURL, md5checksum)
+	if err != nil {
+		return "", fmt.Errorf("failed to start download: %s", err)
+	}
+	return jobID, nil
+}
+
+// RetryDownloadPackage retries the previously failed download package job
+// for the specified cluster. Returns the new job ID.
+func (a API) RetryDownloadPackage(ctx context.Context, clusterID uuid.UUID) (string, error) {
+	a.log.Print(log.Trace)
+
+	jobID, err := gqlcluster.RetryDownloadPackageJob(ctx, a.client.GQL, clusterID)
+	if err != nil {
+		return "", fmt.Errorf("failed to retry download package: %s", err)
+	}
+	return jobID, nil
+}
+
+// WaitForDownload polls the cluster's upgrade state until the package is
+// staged (success), a terminal download failure is observed (returned as a
+// wrapped error), or ctx is cancelled. The returned CDMInfo is the most
+// recent observation regardless of outcome. Backoff is exponential, capped at
+// upgradePollMaxDelay. Transient errors from individual poll requests are
+// logged at Warn and tolerated — only ctx cancellation aborts the wait.
+//
+// The server runs prechecks synchronously at the tail of the download flow.
+// Any state past DOWNLOADING (PRECHECKING, READY_FOR_UPGRADE, etc.) means the
+// package is on the cluster, so WaitForDownload returns there rather than
+// blocking on prechecks — that's a downstream concern. PRECHECK_FAILED is
+// also returned early because it leaves the cluster unable to naturally
+// progress to READY_FOR_UPGRADE without operator intervention.
+//
+// The staged-success path is version-checked: READY_FOR_UPGRADE only counts
+// as success (nil error) when its reported target version equals
+// targetVersion (see IsStaged). A cluster sitting in READY_FOR_UPGRADE for a
+// different version does not short-circuit the wait — it keeps polling until
+// the cluster transitions or ctx is cancelled, so callers should always pass
+// a ctx with a deadline. The other post-download states (PRECHECKING,
+// UPGRADING, etc.) are still returned with a nil error without a version
+// check, since reaching them at all implies a package was staged.
+//
+// Calling DownloadPackage immediately followed by WaitForDownload is
+// race-prone: if the cluster was already in READY_FOR_UPGRADE for
+// targetVersion (e.g. from a previous successful download), the first poll
+// will see that stale state and return before the new operation has even
+// registered. Callers wanting trigger-then-wait semantics should capture the
+// pre-trigger state and wait for a transition before applying completion
+// checks.
+func (a API) WaitForDownload(ctx context.Context, clusterID uuid.UUID, targetVersion string) (gqlcluster.CDMInfo, error) {
+	a.log.Print(log.Trace)
+
+	delay := upgradePollInitialDelay
+	var last gqlcluster.CDMInfo
+	for {
+		details, err := a.ClusterUpgrade(ctx, clusterID)
+		if err != nil {
+			a.log.Printf(log.Warn, "WaitForDownload poll for cluster %q failed (will retry): %s", clusterID, err)
+		} else if details.CDMInfo != nil {
+			last = *details.CDMInfo
+			if details.CDMInfo.IsStaged(targetVersion) {
+				return last, nil
+			}
+			if isDownloadTerminalFailure(last) {
+				return last, fmt.Errorf("cluster %q download of %q failed: %s",
+					clusterID, targetVersion, downloadFailureReason(last))
+			}
+			// Any state past DOWNLOADING means the package is staged. The
+			// version-checked READY_FOR_UPGRADE (handled above) and the
+			// pre-progress WAITING_FOR_OPERATION_TO_START are deliberately
+			// excluded.
+			if v2 := last.UpgradeStatusV2; v2 != nil {
+				switch v2.RSCClusterUpgradeStatus {
+				case gqlcluster.RSCUpgradeStatusPrechecking,
+					gqlcluster.RSCUpgradeStatusPrecheckFailed,
+					gqlcluster.RSCUpgradeStatusUpgrading,
+					gqlcluster.RSCUpgradeStatusUpgradeFailed,
+					gqlcluster.RSCUpgradeStatusRollingBack,
+					gqlcluster.RSCUpgradeStatusRollingBackFailed:
+					return last, nil
+				}
+			}
+		}
+
+		timer := time.NewTimer(delay)
+		select {
+		case <-ctx.Done():
+			timer.Stop()
+			return last, fmt.Errorf("wait for cluster %q download of %q: %w",
+				clusterID, targetVersion, ctx.Err())
+		case <-timer.C:
+		}
+
+		if delay < upgradePollMaxDelay {
+			delay *= 2
+			if delay > upgradePollMaxDelay {
+				delay = upgradePollMaxDelay
+			}
+		}
+	}
+}
+
+func isDownloadTerminalFailure(info gqlcluster.CDMInfo) bool {
+	if info.UpgradeStatusV2 != nil {
+		return info.UpgradeStatusV2.RSCClusterUpgradeStatus == gqlcluster.RSCUpgradeStatusDownloadFailed
+	}
+	return info.ClusterJobStatus == gqlcluster.ClusterJobStatusDownloadPackageFailed
+}
+
+func downloadFailureReason(info gqlcluster.CDMInfo) string {
+	if info.UpgradeStatusV2 != nil {
+		return string(info.UpgradeStatusV2.RSCClusterUpgradeStatus)
+	}
+	return string(info.ClusterJobStatus)
 }

--- a/pkg/polaris/cluster/upgrade_test.go
+++ b/pkg/polaris/cluster/upgrade_test.go
@@ -27,12 +27,15 @@ import (
 	"fmt"
 	"net/http"
 	"net/http/httptest"
+	"strings"
 	"testing"
+	"time"
 
 	"github.com/google/uuid"
 	"github.com/rubrikinc/rubrik-polaris-sdk-for-go/internal/assert"
 	"github.com/rubrikinc/rubrik-polaris-sdk-for-go/internal/handler"
 	"github.com/rubrikinc/rubrik-polaris-sdk-for-go/pkg/polaris/graphql"
+	gqlcluster "github.com/rubrikinc/rubrik-polaris-sdk-for-go/pkg/polaris/graphql/cluster"
 )
 
 // pageResponse returns a JSON response with the given details, cursor, and
@@ -212,5 +215,224 @@ func TestClusterUpgradeFound(t *testing.T) {
 	}
 	if got.CDMInfo == nil || got.CDMInfo.Version != "9.2.1" {
 		t.Errorf("CDMInfo: got %+v", got.CDMInfo)
+	}
+}
+
+// shortenPollDelays sets the WaitForDownload poll intervals to a few
+// milliseconds so polling-loop tests finish quickly.
+func shortenPollDelays(t *testing.T) {
+	t.Helper()
+	origInitial, origMax := upgradePollInitialDelay, upgradePollMaxDelay
+	upgradePollInitialDelay = 5 * time.Millisecond
+	upgradePollMaxDelay = 10 * time.Millisecond
+	t.Cleanup(func() {
+		upgradePollInitialDelay = origInitial
+		upgradePollMaxDelay = origMax
+	})
+}
+
+// upgradeNode renders a clusterWithUpgradesInfo node with the given V2 status
+// and (optional) target version in UIStatusAttributes.
+func upgradeNode(id uuid.UUID, v2 gqlcluster.RSCUpgradeStatusType, targetVersion string) string {
+	return fmt.Sprintf(`{"id":%q,"name":"c","cdmUpgradeInfo":{"clusterUuid":%q,"version":"9.2.1","upgradeStatusV2":{"rscClusterUpgradeStatus":%q,"uiStatus":"","uiStatusAttributes":{"sourceVersion":"","targetVersion":%q,"progress":0,"errorMsg":"","upgradeMode":""}}}}`, id, id, v2, targetVersion)
+}
+
+// scriptedGraphQL serves canned responses for each operation name. Each entry
+// is consumed in order; a missing entry / unknown op returns 500. Used to
+// script a sequence of polling responses.
+type scriptedGraphQL struct {
+	t         *testing.T
+	responses map[string][]string
+	calls     map[string]int
+}
+
+func newScriptedGraphQL(t *testing.T) *scriptedGraphQL {
+	return &scriptedGraphQL{t: t, responses: map[string][]string{}, calls: map[string]int{}}
+}
+
+func (s *scriptedGraphQL) script(op string, responses ...string) {
+	s.responses[op] = append(s.responses[op], responses...)
+}
+
+func (s *scriptedGraphQL) handler() http.HandlerFunc {
+	return func(w http.ResponseWriter, req *http.Request) {
+		var body struct {
+			OperationName string `json:"operationName"`
+		}
+		if err := json.NewDecoder(req.Body).Decode(&body); err != nil {
+			http.Error(w, err.Error(), http.StatusBadRequest)
+			return
+		}
+		s.calls[body.OperationName]++
+		queue := s.responses[body.OperationName]
+		if len(queue) == 0 {
+			s.t.Errorf("no scripted response for op %q (call #%d)", body.OperationName, s.calls[body.OperationName])
+			http.Error(w, "no scripted response", http.StatusInternalServerError)
+			return
+		}
+		// Repeat the last scripted response for subsequent calls.
+		next := queue[0]
+		if len(queue) > 1 {
+			s.responses[body.OperationName] = queue[1:]
+		}
+		fmt.Fprint(w, next)
+	}
+}
+
+func clusterUpgradeResp(node string) string {
+	return fmt.Sprintf(`{"data":{"result":{"edges":[{"cursor":"c","node":%s}],"pageInfo":{"startCursor":"","endCursor":"c","hasPreviousPage":false,"hasNextPage":false},"count":1}}}`, node)
+}
+
+func TestWaitForDownloadStagesSuccessfully(t *testing.T) {
+	shortenPollDelays(t)
+	ctx, cancel := context.WithCancelCause(context.Background())
+	defer assert.Context(t, ctx, cancel)
+
+	id := uuid.MustParse("11111111-1111-1111-1111-111111111111")
+	target := "9.3.3-p8-29908"
+
+	s := newScriptedGraphQL(t)
+	s.script("SdkGolangClusterWithUpgradesInfo",
+		clusterUpgradeResp(upgradeNode(id, gqlcluster.RSCUpgradeStatusDownloading, target)),
+		clusterUpgradeResp(upgradeNode(id, gqlcluster.RSCUpgradeStatusDownloading, target)),
+		clusterUpgradeResp(upgradeNode(id, gqlcluster.RSCUpgradeStatusReadyForUpgrade, target)),
+	)
+
+	srv := httptest.NewServer(handler.GraphQL(s.handler()))
+	defer srv.Close()
+
+	info, err := Wrap(newTestClient(srv)).WaitForDownload(ctx, id, target)
+	if err != nil {
+		t.Fatalf("WaitForDownload: %v", err)
+	}
+	if info.UpgradeStatusV2 == nil || info.UpgradeStatusV2.RSCClusterUpgradeStatus != gqlcluster.RSCUpgradeStatusReadyForUpgrade {
+		t.Errorf("expected final state ReadyForUpgrade, got %+v", info.UpgradeStatusV2)
+	}
+	if s.calls["SdkGolangClusterWithUpgradesInfo"] != 3 {
+		t.Errorf("expected 3 polls, got %d", s.calls["SdkGolangClusterWithUpgradesInfo"])
+	}
+}
+
+func TestWaitForDownloadTerminalFailure(t *testing.T) {
+	shortenPollDelays(t)
+	ctx, cancel := context.WithCancelCause(context.Background())
+	defer assert.Context(t, ctx, cancel)
+
+	id := uuid.MustParse("11111111-1111-1111-1111-111111111111")
+	target := "9.3.3-p8-29908"
+
+	s := newScriptedGraphQL(t)
+	s.script("SdkGolangClusterWithUpgradesInfo",
+		clusterUpgradeResp(upgradeNode(id, gqlcluster.RSCUpgradeStatusDownloading, target)),
+		clusterUpgradeResp(upgradeNode(id, gqlcluster.RSCUpgradeStatusDownloadFailed, target)),
+	)
+
+	srv := httptest.NewServer(handler.GraphQL(s.handler()))
+	defer srv.Close()
+
+	_, err := Wrap(newTestClient(srv)).WaitForDownload(ctx, id, target)
+	if err == nil {
+		t.Fatal("expected error, got nil")
+	}
+	if !strings.Contains(err.Error(), "DOWNLOAD_FAILED") {
+		t.Errorf("error should mention DOWNLOAD_FAILED, got: %v", err)
+	}
+}
+
+func TestWaitForDownloadReturnsOnPostDownload(t *testing.T) {
+	shortenPollDelays(t)
+	ctx, cancel := context.WithCancelCause(context.Background())
+	defer assert.Context(t, ctx, cancel)
+
+	id := uuid.MustParse("11111111-1111-1111-1111-111111111111")
+	target := "9.3.3-p8-29908"
+
+	s := newScriptedGraphQL(t)
+	// Server runs prechecks at the tail of download. PRECHECKING means package
+	// is on the cluster; WaitForDownload should return without waiting for
+	// READY_FOR_UPGRADE.
+	s.script("SdkGolangClusterWithUpgradesInfo",
+		clusterUpgradeResp(upgradeNode(id, gqlcluster.RSCUpgradeStatusDownloading, target)),
+		clusterUpgradeResp(upgradeNode(id, gqlcluster.RSCUpgradeStatusPrechecking, target)),
+	)
+
+	srv := httptest.NewServer(handler.GraphQL(s.handler()))
+	defer srv.Close()
+
+	info, err := Wrap(newTestClient(srv)).WaitForDownload(ctx, id, target)
+	if err != nil {
+		t.Fatalf("WaitForDownload: %v", err)
+	}
+	if info.UpgradeStatusV2.RSCClusterUpgradeStatus != gqlcluster.RSCUpgradeStatusPrechecking {
+		t.Errorf("expected PRECHECKING, got %s", info.UpgradeStatusV2.RSCClusterUpgradeStatus)
+	}
+}
+
+// TestWaitForDownloadIgnoresWaitingForOperationStart is a regression test for
+// the bug where WAITING_FOR_OPERATION_TO_START — the pre-progress state right
+// after any operation is triggered — was treated as post-download and caused
+// WaitForDownload to return immediately.
+func TestWaitForDownloadIgnoresWaitingForOperationStart(t *testing.T) {
+	shortenPollDelays(t)
+	ctx, cancel := context.WithCancelCause(context.Background())
+	defer assert.Context(t, ctx, cancel)
+
+	id := uuid.MustParse("11111111-1111-1111-1111-111111111111")
+	target := "9.3.3-p8-29908"
+
+	s := newScriptedGraphQL(t)
+	s.script("SdkGolangClusterWithUpgradesInfo",
+		clusterUpgradeResp(upgradeNode(id, gqlcluster.RSCUpgradeStatusWaitingForOperationStart, "")),
+		clusterUpgradeResp(upgradeNode(id, gqlcluster.RSCUpgradeStatusDownloading, target)),
+		clusterUpgradeResp(upgradeNode(id, gqlcluster.RSCUpgradeStatusReadyForUpgrade, target)),
+	)
+
+	srv := httptest.NewServer(handler.GraphQL(s.handler()))
+	defer srv.Close()
+
+	info, err := Wrap(newTestClient(srv)).WaitForDownload(ctx, id, target)
+	if err != nil {
+		t.Fatalf("WaitForDownload: %v", err)
+	}
+	if info.UpgradeStatusV2.RSCClusterUpgradeStatus != gqlcluster.RSCUpgradeStatusReadyForUpgrade {
+		t.Errorf("expected final state ReadyForUpgrade, got %s", info.UpgradeStatusV2.RSCClusterUpgradeStatus)
+	}
+	if s.calls["SdkGolangClusterWithUpgradesInfo"] != 3 {
+		t.Errorf("expected 3 polls (WAITING_FOR_OPERATION_TO_START must not short-circuit), got %d", s.calls["SdkGolangClusterWithUpgradesInfo"])
+	}
+}
+
+// TestWaitForDownloadTargetVer is a regression test ensuring a cluster
+// sitting in READY_FOR_UPGRADE for a version other than the requested target
+// does not short-circuit the wait. Only once the target version is staged
+// should WaitForDownload return success.
+func TestWaitForDownloadTargetVer(t *testing.T) {
+	shortenPollDelays(t)
+	ctx, cancel := context.WithCancelCause(context.Background())
+	defer assert.Context(t, ctx, cancel)
+
+	id := uuid.MustParse("11111111-1111-1111-1111-111111111111")
+	target := "9.3.3-p8-29908"
+	stale := "9.2.1-p1-12345"
+
+	s := newScriptedGraphQL(t)
+	s.script("SdkGolangClusterWithUpgradesInfo",
+		clusterUpgradeResp(upgradeNode(id, gqlcluster.RSCUpgradeStatusReadyForUpgrade, stale)),
+		clusterUpgradeResp(upgradeNode(id, gqlcluster.RSCUpgradeStatusDownloading, target)),
+		clusterUpgradeResp(upgradeNode(id, gqlcluster.RSCUpgradeStatusReadyForUpgrade, target)),
+	)
+
+	srv := httptest.NewServer(handler.GraphQL(s.handler()))
+	defer srv.Close()
+
+	info, err := Wrap(newTestClient(srv)).WaitForDownload(ctx, id, target)
+	if err != nil {
+		t.Fatalf("WaitForDownload: %v", err)
+	}
+	if info.UpgradeStatusV2.UIStatusAttributes.TargetVersion != target {
+		t.Errorf("expected staged target %q, got %q", target, info.UpgradeStatusV2.UIStatusAttributes.TargetVersion)
+	}
+	if s.calls["SdkGolangClusterWithUpgradesInfo"] != 3 {
+		t.Errorf("expected 3 polls (stale READY_FOR_UPGRADE must not short-circuit), got %d", s.calls["SdkGolangClusterWithUpgradesInfo"])
 	}
 }

--- a/pkg/polaris/graphql/cluster/queries.go
+++ b/pkg/polaris/graphql/cluster/queries.go
@@ -365,6 +365,13 @@ var removeCdmClusterQuery = `mutation SdkGolangRemoveCdmCluster($clusterUuid: UU
   )
 }`
 
+// retryDownloadPackageJob GraphQL query
+var retryDownloadPackageJobQuery = `mutation SdkGolangRetryDownloadPackageJob($clusterUuid: UUID!) {
+  result: retryDownloadPackageJob(clusterUuid: $clusterUuid) {
+    jobId
+  }
+}`
+
 // selfServeRollingUpgrade GraphQL query
 var selfServeRollingUpgradeQuery = `query SdkGolangSelfServeRollingUpgrade {
   result: selfServeRollingUpgrade {
@@ -441,6 +448,21 @@ var slaSourceClustersQuery = `query SdkGolangSlaSourceClusters(
       hasNextPage
     }
     count
+  }
+}`
+
+// startDownloadPackageBatchJob GraphQL query
+var startDownloadPackageBatchJobQuery = `mutation SdkGolangStartDownloadPackageBatchJob(
+  $listClusterUuid: [UUID!]!
+  $packageUrl: String!
+  $md5checksum: String!
+) {
+  result: startDownloadPackageBatchJob(
+    listClusterUuid: $listClusterUuid
+    packageUrl: $packageUrl
+    md5checksum: $md5checksum
+  ) {
+    jobId
   }
 }`
 

--- a/pkg/polaris/graphql/cluster/queries/retry_download_package_job.graphql
+++ b/pkg/polaris/graphql/cluster/queries/retry_download_package_job.graphql
@@ -1,0 +1,5 @@
+mutation RubrikPolarisSDKRequest($clusterUuid: UUID!) {
+  result: retryDownloadPackageJob(clusterUuid: $clusterUuid) {
+    jobId
+  }
+}

--- a/pkg/polaris/graphql/cluster/queries/start_download_package_batch_job.graphql
+++ b/pkg/polaris/graphql/cluster/queries/start_download_package_batch_job.graphql
@@ -1,0 +1,13 @@
+mutation RubrikPolarisSDKRequest(
+  $listClusterUuid: [UUID!]!
+  $packageUrl: String!
+  $md5checksum: String!
+) {
+  result: startDownloadPackageBatchJob(
+    listClusterUuid: $listClusterUuid
+    packageUrl: $packageUrl
+    md5checksum: $md5checksum
+  ) {
+    jobId
+  }
+}

--- a/pkg/polaris/graphql/cluster/upgrade.go
+++ b/pkg/polaris/graphql/cluster/upgrade.go
@@ -404,6 +404,70 @@ func UpgradeStatus(ctx context.Context, gql *graphql.Client, clusterID uuid.UUID
 	return payload.Data.Result.CurrentStateName, nil
 }
 
+// StartDownloadPackage initiates a download of the package at packageURL onto
+// the specified cluster. The server parses the version from the package
+// filename, which must follow the `rubrik-image-<version>.zip` convention.
+// Returns the per-cluster job ID; poll the cluster's upgrade status to track
+// progress.
+func StartDownloadPackage(ctx context.Context, gql *graphql.Client, clusterID uuid.UUID, packageURL, md5checksum string) (string, error) {
+	gql.Log().Print(log.Trace)
+
+	query := startDownloadPackageBatchJobQuery
+	buf, err := gql.Request(ctx, query, struct {
+		ListClusterUUID []uuid.UUID `json:"listClusterUuid"`
+		PackageURL      string      `json:"packageUrl"`
+		Md5Checksum     string      `json:"md5checksum"`
+	}{
+		ListClusterUUID: []uuid.UUID{clusterID},
+		PackageURL:      packageURL,
+		Md5Checksum:     md5checksum,
+	})
+	if err != nil {
+		return "", graphql.RequestError(query, err)
+	}
+
+	var payload struct {
+		Data struct {
+			Result []struct {
+				JobID string `json:"jobId"`
+			} `json:"result"`
+		} `json:"data"`
+	}
+	if err := json.Unmarshal(buf, &payload); err != nil {
+		return "", graphql.UnmarshalError(query, err)
+	}
+	if len(payload.Data.Result) != 1 {
+		return "", graphql.ResponseError(query, fmt.Errorf("expected 1 reply, got %d", len(payload.Data.Result)))
+	}
+	return payload.Data.Result[0].JobID, nil
+}
+
+// RetryDownloadPackageJob retries the previously failed download package job
+// for the specified cluster. Returns the new job ID.
+func RetryDownloadPackageJob(ctx context.Context, gql *graphql.Client, clusterID uuid.UUID) (string, error) {
+	gql.Log().Print(log.Trace)
+
+	query := retryDownloadPackageJobQuery
+	buf, err := gql.Request(ctx, query, struct {
+		ClusterUUID uuid.UUID `json:"clusterUuid"`
+	}{ClusterUUID: clusterID})
+	if err != nil {
+		return "", graphql.RequestError(query, err)
+	}
+
+	var payload struct {
+		Data struct {
+			Result struct {
+				JobID string `json:"jobId"`
+			} `json:"result"`
+		} `json:"data"`
+	}
+	if err := json.Unmarshal(buf, &payload); err != nil {
+		return "", graphql.UnmarshalError(query, err)
+	}
+	return payload.Data.Result.JobID, nil
+}
+
 // UpgradeInfoSortBy represents the sort field for cluster upgrade info queries.
 type UpgradeInfoSortBy string
 
@@ -586,6 +650,21 @@ type CDMInfo struct {
 	UpgradeStatusV2           *UpgradeStatusV2           `json:"upgradeStatusV2,omitzero"`
 	UpgradeRecommendationInfo *UpgradeRecommendationInfo `json:"upgradeRecommendationInfo,omitzero"`
 	LastUpgradeDuration       *UpgradeDuration           `json:"lastUpgradeDuration,omitzero"`
+}
+
+// IsStaged reports whether the cluster has stagedVersion downloaded and is in
+// the ReadyForUpgrade state. Prefers the V2 upgradeStatusV2 payload over the
+// legacy V1 fields, falling back to V1 when V2 is absent.
+func (info *CDMInfo) IsStaged(stagedVersion string) bool {
+	if info == nil {
+		return false
+	}
+	if info.UpgradeStatusV2 != nil {
+		return info.UpgradeStatusV2.RSCClusterUpgradeStatus == RSCUpgradeStatusReadyForUpgrade &&
+			info.UpgradeStatusV2.UIStatusAttributes.TargetVersion == stagedVersion
+	}
+	return info.DownloadedVersion == stagedVersion &&
+		info.ClusterJobStatus == ClusterJobStatusReadyForUpgrade
 }
 
 // UpgradeDetails bundles the cluster identity with its upgrade info, as


### PR DESCRIPTION
# Description

Adds DownloadPackage and RetryDownloadPackage high-level wrappers over the startDownloadPackageBatchJob and retryDownloadPackageJob mutations. Both take a single cluster; s-suffixed multi-cluster variants can be added later if needed.

WaitForDownload polls the aggregated upgrade view until the package is staged or a terminal download failure is observed. Terminal-state and post-download detection use the V2 UpgradeStatusV2.RSCClusterUpgradeStatus enum. WaitForDownload also returns early once the cluster has moved past the download phase (PRECHECKING and later) since the server runs prechecks synchronously at the tail of the download flow.

Adds IsStaged on CDMInfo, which keys off the V2 status and target version with a V1 fallback.

The server parses the version from the package URL filename (which must follow the rubrik-image-<version>.zip convention); the size parameter is unexposed.

WaitForDownload's doc notes that calling it immediately after DownloadPackage is race-prone when the cluster's pre-trigger state already matches the target version. A race-safe composite is the natural follow-up.

## How Has This Been Tested?

Manually + new unit tests.

## Types of changes

What types of changes does your code introduce? Put an `x` in all the boxes that apply:
- [ ] Bug fix (non-breaking change which fixes an issue)
- [x] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)
- [ ] Other (please describe in the Description above)

## Checklist:

Go over all the following points, and put an `x` in all the boxes that apply. If you're unsure about any of these, don't hesitate to ask. We're here to help!
- [x] My code follows the code style of this project.
- [ ] My change requires a change to the documentation.
- [ ] I have updated the documentation accordingly.
- [ ] I have updated the CHANGELOG file accordingly for the version that this merge modifies.
- [x] I have added tests to cover my changes.
- [x] All new and existing tests passed.
