### PR TITLE
Add cluster upgrade "DownloadPackageAndWait"

### DIFF
--- a/pkg/polaris/cluster/upgrade.go
+++ b/pkg/polaris/cluster/upgrade.go
@@ -192,9 +192,7 @@ func (a API) RetryDownloadPackage(ctx context.Context, clusterID uuid.UUID) (str
 // race-prone: if the cluster was already in READY_FOR_UPGRADE for
 // targetVersion (e.g. from a previous successful download), the first poll
 // will see that stale state and return before the new operation has even
-// registered. Callers wanting trigger-then-wait semantics should capture the
-// pre-trigger state and wait for a transition before applying completion
-// checks.
+// registered. Use DownloadPackageAndWait for the race-safe composite.
 func (a API) WaitForDownload(ctx context.Context, clusterID uuid.UUID, targetVersion string) (gqlcluster.CDMInfo, error) {
 	a.log.Print(log.Trace)
 
@@ -239,12 +237,7 @@ func (a API) WaitForDownload(ctx context.Context, clusterID uuid.UUID, targetVer
 		case <-timer.C:
 		}
 
-		if delay < upgradePollMaxDelay {
-			delay *= 2
-			if delay > upgradePollMaxDelay {
-				delay = upgradePollMaxDelay
-			}
-		}
+		delay = nextBackoff(delay, upgradePollMaxDelay)
 	}
 }
 
@@ -260,4 +253,129 @@ func downloadFailureReason(info gqlcluster.CDMInfo) string {
 		return string(info.UpgradeStatusV2.RSCClusterUpgradeStatus)
 	}
 	return string(info.ClusterJobStatus)
+}
+
+// nextBackoff doubles cur, clamping to max. Shared by the upgrade poll loops.
+func nextBackoff(cur, max time.Duration) time.Duration {
+	if cur >= max {
+		return max
+	}
+	if cur *= 2; cur > max {
+		return max
+	}
+	return cur
+}
+
+// transitionPollInitialDelay is the first sleep when polling for a
+// post-trigger state transition. Short because the cluster typically picks
+// the new operation up within seconds.
+var transitionPollInitialDelay = time.Second
+
+// transitionPollMaxDelay caps the exponential backoff between transition
+// polls.
+var transitionPollMaxDelay = 5 * time.Second
+
+// DownloadPackageAndWait triggers a download of the package at packageURL onto
+// the specified cluster and blocks until the package is staged or a terminal
+// download failure is observed. The returned CDMInfo is the most recent
+// observation regardless of outcome.
+//
+// Unlike calling DownloadPackage followed by WaitForDownload, this composite
+// snapshots the cluster's pre-trigger state and waits for an observed state
+// transition before applying completion checks. That avoids a race where the
+// cluster was already in READY_FOR_UPGRADE for targetVersion (e.g. a previous
+// download attempt), which would otherwise cause WaitForDownload to return
+// success before the new operation has registered.
+//
+// targetVersion is required and must match the version encoded in the package
+// URL filename (which the server itself parses for the trigger).
+func (a API) DownloadPackageAndWait(ctx context.Context, clusterID uuid.UUID, packageURL, md5checksum, targetVersion string) (gqlcluster.CDMInfo, error) {
+	a.log.Print(log.Trace)
+
+	preDetails, err := a.ClusterUpgrade(ctx, clusterID)
+	if err != nil {
+		return gqlcluster.CDMInfo{}, fmt.Errorf("snapshot pre-trigger cluster upgrade: %s", err)
+	}
+	var preV2 gqlcluster.RSCUpgradeStatusType
+	if preDetails.CDMInfo != nil && preDetails.CDMInfo.UpgradeStatusV2 != nil {
+		preV2 = preDetails.CDMInfo.UpgradeStatusV2.RSCClusterUpgradeStatus
+	}
+	// If the cluster already looks staged for targetVersion, the live V1 state
+	// can lead the slower V2 aggregator: releasing on a V1 transition would let
+	// WaitForDownload succeed on the stale READY_FOR_UPGRADE@targetVersion. In
+	// that case the gate ignores V1, so skip the V1 snapshot entirely. IsStaged
+	// is nil-safe.
+	preStaged := preDetails.CDMInfo.IsStaged(targetVersion)
+	var preV1 gqlcluster.UpgradeState
+	if !preStaged {
+		if preV1, err = a.UpgradeStatus(ctx, clusterID); err != nil {
+			return gqlcluster.CDMInfo{}, fmt.Errorf("snapshot pre-trigger upgrade status: %s", err)
+		}
+	}
+	a.log.Printf(log.Debug, "DownloadPackageAndWait cluster %q baseline: V1=%s V2=%s staged=%t", clusterID, preV1, preV2, preStaged)
+
+	if _, err := a.DownloadPackage(ctx, clusterID, packageURL, md5checksum); err != nil {
+		return gqlcluster.CDMInfo{}, err
+	}
+
+	if err := a.waitForDownloadTransition(ctx, clusterID, preV1, preV2, targetVersion, preStaged); err != nil {
+		return gqlcluster.CDMInfo{}, err
+	}
+
+	return a.WaitForDownload(ctx, clusterID, targetVersion)
+}
+
+// waitForDownloadTransition polls until the just-triggered operation has
+// registered, then returns.
+//
+// Normally it releases as soon as either V1 (live upgradeStatus) or V2
+// (aggregated UpgradeStatusV2) differs from the captured baselines. When the
+// cluster was already staged for targetVersion before the trigger (preStaged),
+// the V1 signal is ignored: V1 leads the slower V2 aggregator, and releasing on
+// V1 alone would let WaitForDownload short-circuit on the stale
+// READY_FOR_UPGRADE@targetVersion. In that case the gate releases only once a
+// V2 observation is no longer staged for targetVersion.
+//
+// Transient errors from individual polls are tolerated; only ctx cancellation
+// aborts.
+func (a API) waitForDownloadTransition(ctx context.Context, clusterID uuid.UUID, preV1 gqlcluster.UpgradeState, preV2 gqlcluster.RSCUpgradeStatusType, targetVersion string, preStaged bool) error {
+	delay := transitionPollInitialDelay
+	for {
+		timer := time.NewTimer(delay)
+		select {
+		case <-ctx.Done():
+			timer.Stop()
+			return fmt.Errorf("wait for cluster %q to register download: %w", clusterID, ctx.Err())
+		case <-timer.C:
+		}
+
+		// V1 leads the V2 aggregator, so trust it only when the pre-trigger
+		// state was not already staged for targetVersion.
+		if !preStaged {
+			if v1, err := a.UpgradeStatus(ctx, clusterID); err != nil {
+				a.log.Printf(log.Warn, "DownloadPackageAndWait V1 poll for cluster %q failed (will retry): %s", clusterID, err)
+			} else if v1 != preV1 {
+				a.log.Printf(log.Debug, "DownloadPackageAndWait cluster %q V1 transitioned %s -> %s", clusterID, preV1, v1)
+				return nil
+			}
+		}
+
+		if details, err := a.ClusterUpgrade(ctx, clusterID); err != nil {
+			a.log.Printf(log.Warn, "DownloadPackageAndWait V2 poll for cluster %q failed (will retry): %s", clusterID, err)
+		} else if details.CDMInfo != nil {
+			if preStaged {
+				// Release only once V2 has left the stale staged state, so
+				// WaitForDownload cannot succeed on the pre-trigger observation.
+				if !details.CDMInfo.IsStaged(targetVersion) {
+					a.log.Printf(log.Debug, "DownloadPackageAndWait cluster %q V2 left stale staged state", clusterID)
+					return nil
+				}
+			} else if v2 := details.CDMInfo.UpgradeStatusV2; v2 != nil && v2.RSCClusterUpgradeStatus != preV2 {
+				a.log.Printf(log.Debug, "DownloadPackageAndWait cluster %q V2 transitioned %s -> %s", clusterID, preV2, v2.RSCClusterUpgradeStatus)
+				return nil
+			}
+		}
+
+		delay = nextBackoff(delay, transitionPollMaxDelay)
+	}
 }

--- a/pkg/polaris/cluster/upgrade_test.go
+++ b/pkg/polaris/cluster/upgrade_test.go
@@ -218,16 +218,21 @@ func TestClusterUpgradeFound(t *testing.T) {
 	}
 }
 
-// shortenPollDelays sets the WaitForDownload poll intervals to a few
+// shortenPollDelays sets all wait/transition poll intervals to a few
 // milliseconds so polling-loop tests finish quickly.
 func shortenPollDelays(t *testing.T) {
 	t.Helper()
-	origInitial, origMax := upgradePollInitialDelay, upgradePollMaxDelay
+	origUpgradeInitial, origUpgradeMax := upgradePollInitialDelay, upgradePollMaxDelay
+	origTransInitial, origTransMax := transitionPollInitialDelay, transitionPollMaxDelay
 	upgradePollInitialDelay = 5 * time.Millisecond
 	upgradePollMaxDelay = 10 * time.Millisecond
+	transitionPollInitialDelay = 2 * time.Millisecond
+	transitionPollMaxDelay = 5 * time.Millisecond
 	t.Cleanup(func() {
-		upgradePollInitialDelay = origInitial
-		upgradePollMaxDelay = origMax
+		upgradePollInitialDelay = origUpgradeInitial
+		upgradePollMaxDelay = origUpgradeMax
+		transitionPollInitialDelay = origTransInitial
+		transitionPollMaxDelay = origTransMax
 	})
 }
 
@@ -281,6 +286,10 @@ func (s *scriptedGraphQL) handler() http.HandlerFunc {
 
 func clusterUpgradeResp(node string) string {
 	return fmt.Sprintf(`{"data":{"result":{"edges":[{"cursor":"c","node":%s}],"pageInfo":{"startCursor":"","endCursor":"c","hasPreviousPage":false,"hasNextPage":false},"count":1}}}`, node)
+}
+
+func upgradeStatusResp(state gqlcluster.UpgradeState) string {
+	return fmt.Sprintf(`{"data":{"result":{"currentStateName":%q}}}`, state)
 }
 
 func TestWaitForDownloadStagesSuccessfully(t *testing.T) {
@@ -434,5 +443,183 @@ func TestWaitForDownloadTargetVer(t *testing.T) {
 	}
 	if s.calls["SdkGolangClusterWithUpgradesInfo"] != 3 {
 		t.Errorf("expected 3 polls (stale READY_FOR_UPGRADE must not short-circuit), got %d", s.calls["SdkGolangClusterWithUpgradesInfo"])
+	}
+}
+
+// TestDownloadPackageAndWaitGuardsAgainstStaleSuccess simulates the
+// re-trigger-same-version race observed against a real cluster: the cluster is
+// already in READY_FOR_UPGRADE for the requested version when
+// DownloadPackageAndWait is called. The composite must NOT short-circuit on
+// the pre-trigger state; it must wait for V2 to transition (via
+// WAITING_FOR_OPERATION_TO_START) before applying completion checks.
+func TestDownloadPackageAndWaitGuardsAgainstStaleSuccess(t *testing.T) {
+	shortenPollDelays(t)
+	ctx, cancel := context.WithCancelCause(context.Background())
+	defer assert.Context(t, ctx, cancel)
+
+	id := uuid.MustParse("11111111-1111-1111-1111-111111111111")
+	target := "9.3.3-p8-29908"
+	staleStaged := upgradeNode(id, gqlcluster.RSCUpgradeStatusReadyForUpgrade, target)
+	// WAITING_FOR_OPERATION_TO_START arrives with empty UIStatusAttributes per
+	// observed live cluster snapshots after a fresh download trigger.
+	waitingForOp := upgradeNode(id, gqlcluster.RSCUpgradeStatusWaitingForOperationStart, "")
+	downloading := upgradeNode(id, gqlcluster.RSCUpgradeStatusDownloading, target)
+	freshStaged := upgradeNode(id, gqlcluster.RSCUpgradeStatusReadyForUpgrade, target)
+
+	s := newScriptedGraphQL(t)
+	// ClusterUpgrade sequence:
+	//   1: snapshot (stale ReadyForUpgrade for target)
+	//   2: gate iter 1 — V2 still stale
+	//   3: gate iter 2 — V2 transitions to WAITING_FOR_OPERATION_TO_START;
+	//      gate releases here
+	//   4: WaitForDownload poll 1 — WAITING_FOR_OPERATION_TO_START (still
+	//      not "post-download", keep polling)
+	//   5: WaitForDownload poll 2 — DOWNLOADING
+	//   6: WaitForDownload poll 3 — ReadyForUpgrade (IsStaged → done)
+	s.script("SdkGolangClusterWithUpgradesInfo",
+		clusterUpgradeResp(staleStaged),
+		clusterUpgradeResp(staleStaged),
+		clusterUpgradeResp(waitingForOp),
+		clusterUpgradeResp(waitingForOp),
+		clusterUpgradeResp(downloading),
+		clusterUpgradeResp(freshStaged),
+	)
+	s.script("SdkGolangStartDownloadPackageBatchJob",
+		`{"data":{"result":[{"jobId":"STAGE_CDM_SOFTWARE_DUMMY_ID"}]}}`)
+	// Pre-staged: V1 is never consulted (snapshot skipped, gate ignores it) —
+	// V2 alone catches the change, so no SdkGolangUpgradeStatus is scripted.
+
+	srv := httptest.NewServer(handler.GraphQL(s.handler()))
+	defer srv.Close()
+
+	info, err := Wrap(newTestClient(srv)).DownloadPackageAndWait(ctx, id, "https://example/rubrik-image-"+target+".zip", "checksum", target)
+	if err != nil {
+		t.Fatalf("DownloadPackageAndWait: %v", err)
+	}
+	if info.UpgradeStatusV2.RSCClusterUpgradeStatus != gqlcluster.RSCUpgradeStatusReadyForUpgrade {
+		t.Errorf("expected final ReadyForUpgrade, got %s", info.UpgradeStatusV2.RSCClusterUpgradeStatus)
+	}
+	if got := s.calls["SdkGolangUpgradeStatus"]; got != 0 {
+		t.Errorf("pre-staged path must not read V1 at all, got %d V1 calls", got)
+	}
+	if got := s.calls["SdkGolangStartDownloadPackageBatchJob"]; got != 1 {
+		t.Errorf("trigger should be called exactly once, got %d", got)
+	}
+	// At least 4 ClusterUpgrade calls: 1 snapshot + 2 gate polls (stale, then
+	// transitioned) + 1+ post-transition polls in WaitForDownload.
+	if got := s.calls["SdkGolangClusterWithUpgradesInfo"]; got < 4 {
+		t.Errorf("expected at least 4 ClusterUpgrade polls (must not short-circuit on stale state), got %d", got)
+	}
+}
+
+// TestDownloadPackageAndWaitPreStagedWaitsForV2 verifies that when the cluster
+// is already staged for the target version, the gate ignores the (faster) V1
+// signal and waits for V2 to actually leave the stale staged state, so
+// WaitForDownload can't short-circuit on the pre-trigger observation.
+func TestDownloadPackageAndWaitPreStagedWaitsForV2(t *testing.T) {
+	shortenPollDelays(t)
+	ctx, cancel := context.WithCancelCause(context.Background())
+	defer assert.Context(t, ctx, cancel)
+
+	id := uuid.MustParse("11111111-1111-1111-1111-111111111111")
+	target := "9.3.3-p8-29908"
+	staleStaged := upgradeNode(id, gqlcluster.RSCUpgradeStatusReadyForUpgrade, target)
+	downloading := upgradeNode(id, gqlcluster.RSCUpgradeStatusDownloading, target)
+	freshStaged := upgradeNode(id, gqlcluster.RSCUpgradeStatusReadyForUpgrade, target)
+
+	s := newScriptedGraphQL(t)
+	//   1: snapshot — staleStaged (→ preStaged)
+	//   2: gate iter 1 — still staleStaged (IsStaged → keep waiting)
+	//   3: gate iter 2 — DOWNLOADING (IsStaged false → release)
+	//   4: WaitForDownload poll — freshStaged (final, IsStaged → done)
+	s.script("SdkGolangClusterWithUpgradesInfo",
+		clusterUpgradeResp(staleStaged),
+		clusterUpgradeResp(staleStaged),
+		clusterUpgradeResp(downloading),
+		clusterUpgradeResp(freshStaged),
+	)
+	s.script("SdkGolangStartDownloadPackageBatchJob",
+		`{"data":{"result":[{"jobId":"STAGE_CDM_SOFTWARE_DUMMY_ID"}]}}`)
+	// No SdkGolangUpgradeStatus is scripted: in the pre-staged path V1 is never
+	// read — not for the snapshot, not as a release signal.
+
+	srv := httptest.NewServer(handler.GraphQL(s.handler()))
+	defer srv.Close()
+
+	info, err := Wrap(newTestClient(srv)).DownloadPackageAndWait(ctx, id, "https://example/rubrik-image-"+target+".zip", "checksum", target)
+	if err != nil {
+		t.Fatalf("DownloadPackageAndWait: %v", err)
+	}
+	if info.UpgradeStatusV2.RSCClusterUpgradeStatus != gqlcluster.RSCUpgradeStatusReadyForUpgrade {
+		t.Errorf("expected final ReadyForUpgrade, got %s", info.UpgradeStatusV2.RSCClusterUpgradeStatus)
+	}
+	// V1 must not be read at all. If it were a release signal, a COPYING
+	// transition would short-circuit the gate while V2 was still stale
+	// staged@target.
+	if got := s.calls["SdkGolangUpgradeStatus"]; got != 0 {
+		t.Errorf("pre-staged gate must not read V1; got %d V1 calls", got)
+	}
+	// At least 3 V2 reads: snapshot + stale gate poll + the non-staged poll
+	// that releases.
+	if got := s.calls["SdkGolangClusterWithUpgradesInfo"]; got < 3 {
+		t.Errorf("expected the gate to wait for V2 to leave the staged state, got %d V2 polls", got)
+	}
+}
+
+// TestDownloadPackageAndWaitReleasesOnV1WhenNotPreStaged verifies the retained
+// V1-release path: when the pre-trigger state is not staged for the target
+// version, a V1 transition is a safe release signal (WaitForDownload cannot
+// falsely short-circuit, since V2 is not in the success state for target).
+func TestDownloadPackageAndWaitReleasesOnV1WhenNotPreStaged(t *testing.T) {
+	shortenPollDelays(t)
+	ctx, cancel := context.WithCancelCause(context.Background())
+	defer assert.Context(t, ctx, cancel)
+
+	id := uuid.MustParse("11111111-1111-1111-1111-111111111111")
+	target := "9.3.3-p8-29908"
+	otherVer := "9.2.1-p1-00000"
+	// Staged for a DIFFERENT version, so IsStaged(target) is false → not
+	// pre-staged.
+	stagedOther := upgradeNode(id, gqlcluster.RSCUpgradeStatusReadyForUpgrade, otherVer)
+	downloading := upgradeNode(id, gqlcluster.RSCUpgradeStatusDownloading, target)
+	freshStaged := upgradeNode(id, gqlcluster.RSCUpgradeStatusReadyForUpgrade, target)
+
+	s := newScriptedGraphQL(t)
+	//   1: snapshot — stagedOther (not staged for target)
+	//   (gate iter 1 — V1 transitions before V2 is queried; entry not consumed)
+	//   2: WaitForDownload poll 1 — DOWNLOADING (keep polling)
+	//   3: WaitForDownload poll 2 — freshStaged (final, IsStaged → done)
+	s.script("SdkGolangClusterWithUpgradesInfo",
+		clusterUpgradeResp(stagedOther),
+		clusterUpgradeResp(downloading),
+		clusterUpgradeResp(freshStaged),
+	)
+	s.script("SdkGolangStartDownloadPackageBatchJob",
+		`{"data":{"result":[{"jobId":"STAGE_CDM_SOFTWARE_DUMMY_ID"}]}}`)
+	// V1: snapshot IDLE, gate iter 1 COPYING — gate releases here (V1 first,
+	// before V2 in the same iteration is queried).
+	s.script("SdkGolangUpgradeStatus",
+		upgradeStatusResp(gqlcluster.UpgradeStateIdle),
+		upgradeStatusResp(gqlcluster.UpgradeStateCopying),
+	)
+
+	srv := httptest.NewServer(handler.GraphQL(s.handler()))
+	defer srv.Close()
+
+	info, err := Wrap(newTestClient(srv)).DownloadPackageAndWait(ctx, id, "https://example/rubrik-image-"+target+".zip", "checksum", target)
+	if err != nil {
+		t.Fatalf("DownloadPackageAndWait: %v", err)
+	}
+	if info.UpgradeStatusV2.RSCClusterUpgradeStatus != gqlcluster.RSCUpgradeStatusReadyForUpgrade {
+		t.Errorf("expected final ReadyForUpgrade, got %s", info.UpgradeStatusV2.RSCClusterUpgradeStatus)
+	}
+	// V1 read twice: snapshot + the gate iter that transitioned and released.
+	if got := s.calls["SdkGolangUpgradeStatus"]; got != 2 {
+		t.Errorf("expected 2 V1 calls (snapshot + gate iter that released), got %d", got)
+	}
+	// Snapshot consumes one V2 read; the gate releases on V1 before its own V2
+	// poll, so the remaining V2 reads belong to WaitForDownload.
+	if got := s.calls["SdkGolangClusterWithUpgradesInfo"]; got != 3 {
+		t.Errorf("expected 3 V2 calls (snapshot + 2 WaitForDownload polls), got %d", got)
 	}
 }


### PR DESCRIPTION
# Description

Combines DownloadPackage and WaitForDownload into a single call that
snapshots the cluster's pre-trigger state and waits for an observed
transition before applying completion checks. Closes the race where the
cluster was already in READY_FOR_UPGRADE for the requested version (e.g.
from a previous successful download), which causes WaitForDownload alone
to return success before the new operation has registered.

The transition gate polls both signals:

  - V1 (live upgradeStatus): tracks the cluster's state-machine directly,
    no aggregate lag, but the cluster's worker has its own pickup latency.
  - V2 (UpgradeStatusV2.RSCClusterUpgradeStatus): aggregated view that
    surfaces WAITING_FOR_OPERATION_TO_START as soon as the UI event is
    registered server-side.

Whichever signal differs from its baseline first releases the gate; then
WaitForDownload runs to completion.

## How Has This Been Tested?

Manually & new unit tests

## Types of changes

What types of changes does your code introduce? Put an `x` in all the boxes that apply:
- [ ] Bug fix (non-breaking change which fixes an issue)
- [x] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)
- [ ] Other (please describe in the Description above)

## Checklist:

Go over all the following points, and put an `x` in all the boxes that apply. If you're unsure about any of these, don't hesitate to ask. We're here to help!
- [x] My code follows the code style of this project.
- [ ] My change requires a change to the documentation.
- [ ] I have updated the documentation accordingly.
- [ ] I have updated the CHANGELOG file accordingly for the version that this merge modifies.
- [x] I have added tests to cover my changes.
- [x] All new and existing tests passed.
