### PR TITLE
Add Cluster upgrade API

### DIFF
--- a/pkg/polaris/cluster/upgrade.go
+++ b/pkg/polaris/cluster/upgrade.go
@@ -379,3 +379,159 @@ func (a API) waitForDownloadTransition(ctx context.Context, clusterID uuid.UUID,
 		delay = nextBackoff(delay, transitionPollMaxDelay)
 	}
 }
+
+// Upgrade kicks off a fresh upgrade on the specified cluster. upgradeType
+// selects between fast (UpgradeTypeFast) and rolling (UpgradeTypeRolling).
+// Returns the per-cluster server reply; if the server rejects the job
+// (reply.Success false), the returned error wraps reply.Message. Poll
+// WaitForUpgrade to block until the cluster is on targetVersion.
+//
+// The mutation also sets the cluster's stored upgrade-type preference (the
+// same value SetUpgradeType configures) to match the chosen upgradeType.
+//
+// Upgrade only triggers a fresh upgrade (START). Recovery actions (resume a
+// failed upgrade, roll back) are not exposed here; callers needing those
+// can use gqlcluster.StartUpgrade directly.
+func (a API) Upgrade(ctx context.Context, clusterID uuid.UUID, upgradeType gqlcluster.UpgradeType, version string) (gqlcluster.UpgradeJobReply, error) {
+	a.log.Print(log.Trace)
+
+	mode := "normal"
+	if upgradeType == gqlcluster.UpgradeTypeRolling {
+		mode = "rolling"
+	}
+	reply, err := gqlcluster.StartUpgrade(ctx, a.client.GQL, clusterID, mode, gqlcluster.ActionStart, version, "")
+	if err != nil {
+		return gqlcluster.UpgradeJobReply{}, fmt.Errorf("failed to start upgrade: %s", err)
+	}
+	if !reply.Success {
+		msg := reply.Message
+		if msg == "" {
+			msg = "no message returned"
+		}
+		return reply, fmt.Errorf("cluster %q upgrade rejected: %s", clusterID, msg)
+	}
+	return reply, nil
+}
+
+// WaitForUpgrade polls the cluster's upgrade state until the installed version
+// matches targetVersion (success), a terminal upgrade failure is observed
+// (returned as a wrapped error), or ctx is cancelled. The returned CDMInfo is
+// the most recent observation regardless of outcome. Backoff is exponential,
+// capped at upgradePollMaxDelay. Transient errors from individual poll
+// requests are logged at Warn and tolerated — only ctx cancellation aborts
+// the wait.
+//
+// An observed ROLLINGBACK status is returned as a wrapped error: once the
+// cluster has decided to roll back, the target version will not be reached
+// without operator intervention. Use WaitForRollback to wait through the
+// rollback itself.
+func (a API) WaitForUpgrade(ctx context.Context, clusterID uuid.UUID, targetVersion string) (gqlcluster.CDMInfo, error) {
+	a.log.Print(log.Trace)
+
+	delay := upgradePollInitialDelay
+	var last gqlcluster.CDMInfo
+	for {
+		details, err := a.ClusterUpgrade(ctx, clusterID)
+		if err != nil {
+			a.log.Printf(log.Warn, "WaitForUpgrade poll for cluster %q failed (will retry): %s", clusterID, err)
+		} else if details.CDMInfo != nil {
+			last = *details.CDMInfo
+			if last.Version == targetVersion {
+				return last, nil
+			}
+			if status, failed := upgradeTerminalFailure(last); failed {
+				return last, fmt.Errorf("cluster %q upgrade to %q failed: %s", clusterID, targetVersion, status)
+			}
+			if upgradeStatus(last) == gqlcluster.RSCUpgradeStatusRollingBack {
+				return last, fmt.Errorf("cluster %q upgrade to %q is rolling back", clusterID, targetVersion)
+			}
+		}
+
+		timer := time.NewTimer(delay)
+		select {
+		case <-ctx.Done():
+			timer.Stop()
+			return last, fmt.Errorf("wait for cluster %q upgrade to %q: %w", clusterID, targetVersion, ctx.Err())
+		case <-timer.C:
+		}
+
+		delay = nextBackoff(delay, upgradePollMaxDelay)
+	}
+}
+
+// WaitForRollback polls the cluster's upgrade state until a rollback settles.
+// When previousVersion is non-empty, success means Version == previousVersion.
+// When previousVersion is empty (the caller doesn't know the target — e.g.
+// CDMInfo.PreviousVersion was not populated), success means the V2 status has
+// left ROLLINGBACK for any non-failure state. ROLLINGBACK_FAILED is returned
+// as a wrapped error.
+//
+// Use this after observing ROLLINGBACK from WaitForUpgrade — WaitForUpgrade
+// treats ROLLINGBACK as a terminal failure of the original upgrade attempt,
+// so this is the dedicated primitive for waiting through the rollback.
+func (a API) WaitForRollback(ctx context.Context, clusterID uuid.UUID, previousVersion string) (gqlcluster.CDMInfo, error) {
+	a.log.Print(log.Trace)
+
+	delay := upgradePollInitialDelay
+	var last gqlcluster.CDMInfo
+	for {
+		details, err := a.ClusterUpgrade(ctx, clusterID)
+		if err != nil {
+			a.log.Printf(log.Warn, "WaitForRollback poll for cluster %q failed (will retry): %s", clusterID, err)
+		} else if details.CDMInfo != nil {
+			last = *details.CDMInfo
+			status := upgradeStatus(last)
+			if status == gqlcluster.RSCUpgradeStatusRollingBackFailed {
+				target := previousVersion
+				if target == "" {
+					target = "previous version"
+				}
+				return last, fmt.Errorf("cluster %q rollback to %q failed", clusterID, target)
+			}
+			if previousVersion != "" {
+				if last.Version == previousVersion {
+					return last, nil
+				}
+			} else if last.UpgradeStatusV2 != nil && status != gqlcluster.RSCUpgradeStatusRollingBack {
+				return last, nil
+			}
+		}
+
+		timer := time.NewTimer(delay)
+		select {
+		case <-ctx.Done():
+			timer.Stop()
+			return last, fmt.Errorf("wait for cluster %q rollback to %q: %w", clusterID, previousVersion, ctx.Err())
+		case <-timer.C:
+		}
+
+		delay = nextBackoff(delay, upgradePollMaxDelay)
+	}
+}
+
+// upgradeStatus returns the V2 status if available; otherwise UNKNOWN.
+func upgradeStatus(info gqlcluster.CDMInfo) gqlcluster.RSCUpgradeStatusType {
+	if info.UpgradeStatusV2 != nil {
+		return info.UpgradeStatusV2.RSCClusterUpgradeStatus
+	}
+	return gqlcluster.RSCUpgradeStatusUnknown
+}
+
+// upgradeTerminalFailure reports whether info indicates a terminal upgrade
+// failure (UPGRADE_FAILED via V2, or the equivalent V1 cluster-job statuses
+// when V2 is absent). The returned string is the status name for use in
+// error messages.
+func upgradeTerminalFailure(info gqlcluster.CDMInfo) (string, bool) {
+	if info.UpgradeStatusV2 != nil {
+		if info.UpgradeStatusV2.RSCClusterUpgradeStatus == gqlcluster.RSCUpgradeStatusUpgradeFailed {
+			return string(info.UpgradeStatusV2.RSCClusterUpgradeStatus), true
+		}
+		return "", false
+	}
+	switch info.ClusterJobStatus {
+	case gqlcluster.ClusterJobStatusUpgradeFailed,
+		gqlcluster.ClusterJobStatusFailedToInitiateUpgrade:
+		return string(info.ClusterJobStatus), true
+	}
+	return "", false
+}

--- a/pkg/polaris/cluster/upgrade_test.go
+++ b/pkg/polaris/cluster/upgrade_test.go
@@ -623,3 +623,171 @@ func TestDownloadPackageAndWaitReleasesOnV1WhenNotPreStaged(t *testing.T) {
 		t.Errorf("expected 3 V2 calls (snapshot + 2 WaitForDownload polls), got %d", got)
 	}
 }
+
+// upgradeNodeAtVersion is like upgradeNode but also sets the installed
+// version on CDMInfo so WaitForUpgrade's `last.Version == targetVersion`
+// completion check can fire.
+func upgradeNodeAtVersion(id uuid.UUID, v2 gqlcluster.RSCUpgradeStatusType, installedVersion string) string {
+	return fmt.Sprintf(`{"id":%q,"name":"c","cdmUpgradeInfo":{"clusterUuid":%q,"version":%q,"upgradeStatusV2":{"rscClusterUpgradeStatus":%q,"uiStatus":"","uiStatusAttributes":{"sourceVersion":"","targetVersion":%q,"progress":0,"errorMsg":"","upgradeMode":""}}}}`, id, id, installedVersion, v2, installedVersion)
+}
+
+func TestUpgradeRejectedReturnsError(t *testing.T) {
+	ctx, cancel := context.WithCancelCause(context.Background())
+	defer assert.Context(t, ctx, cancel)
+
+	id := uuid.MustParse("11111111-1111-1111-1111-111111111111")
+
+	srv := httptest.NewServer(handler.GraphQL(func(w http.ResponseWriter, req *http.Request) {
+		fmt.Fprint(w, `{"data":{"result":[{"upgradeJobReply":{"message":"upgrade path not supported","success":false}}]}}`)
+	}))
+	defer srv.Close()
+
+	reply, err := Wrap(newTestClient(srv)).Upgrade(ctx, id, gqlcluster.UpgradeTypeFast, "9.3.3-p8-29908")
+	if err == nil {
+		t.Fatal("expected error from server rejection")
+	}
+	if !strings.Contains(err.Error(), "upgrade path not supported") {
+		t.Errorf("error should contain server message, got: %v", err)
+	}
+	if reply.Success {
+		t.Errorf("reply.Success should be false")
+	}
+}
+
+func TestWaitForUpgradeReachesTargetVersion(t *testing.T) {
+	shortenPollDelays(t)
+	ctx, cancel := context.WithCancelCause(context.Background())
+	defer assert.Context(t, ctx, cancel)
+
+	id := uuid.MustParse("11111111-1111-1111-1111-111111111111")
+	target := "9.3.3-p8-29908"
+	prev := "9.2.3-p3-29515"
+
+	s := newScriptedGraphQL(t)
+	s.script("SdkGolangClusterWithUpgradesInfo",
+		clusterUpgradeResp(upgradeNodeAtVersion(id, gqlcluster.RSCUpgradeStatusUpgrading, prev)),
+		clusterUpgradeResp(upgradeNodeAtVersion(id, gqlcluster.RSCUpgradeStatusUpgrading, prev)),
+		clusterUpgradeResp(upgradeNodeAtVersion(id, gqlcluster.RSCUpgradeStatusReadyForUpgrade, target)),
+	)
+
+	srv := httptest.NewServer(handler.GraphQL(s.handler()))
+	defer srv.Close()
+
+	info, err := Wrap(newTestClient(srv)).WaitForUpgrade(ctx, id, target)
+	if err != nil {
+		t.Fatalf("WaitForUpgrade: %v", err)
+	}
+	if info.Version != target {
+		t.Errorf("expected installed Version %q, got %q", target, info.Version)
+	}
+}
+
+func TestWaitForUpgradeTerminalFailure(t *testing.T) {
+	shortenPollDelays(t)
+	ctx, cancel := context.WithCancelCause(context.Background())
+	defer assert.Context(t, ctx, cancel)
+
+	id := uuid.MustParse("11111111-1111-1111-1111-111111111111")
+	target := "9.3.3-p8-29908"
+	prev := "9.2.3-p3-29515"
+
+	s := newScriptedGraphQL(t)
+	s.script("SdkGolangClusterWithUpgradesInfo",
+		clusterUpgradeResp(upgradeNodeAtVersion(id, gqlcluster.RSCUpgradeStatusUpgrading, prev)),
+		clusterUpgradeResp(upgradeNodeAtVersion(id, gqlcluster.RSCUpgradeStatusUpgradeFailed, prev)),
+	)
+
+	srv := httptest.NewServer(handler.GraphQL(s.handler()))
+	defer srv.Close()
+
+	_, err := Wrap(newTestClient(srv)).WaitForUpgrade(ctx, id, target)
+	if err == nil {
+		t.Fatal("expected error")
+	}
+	if !strings.Contains(err.Error(), "UPGRADE_FAILED") {
+		t.Errorf("error should mention UPGRADE_FAILED, got: %v", err)
+	}
+}
+
+// TestWaitForUpgradeRollingbackReturnsError verifies WaitForUpgrade returns
+// an error when the cluster has decided to roll back — the original upgrade
+// won't reach its target without operator intervention.
+func TestWaitForUpgradeRollingbackReturnsError(t *testing.T) {
+	shortenPollDelays(t)
+	ctx, cancel := context.WithCancelCause(context.Background())
+	defer assert.Context(t, ctx, cancel)
+
+	id := uuid.MustParse("11111111-1111-1111-1111-111111111111")
+	target := "9.3.3-p8-29908"
+	prev := "9.2.3-p3-29515"
+
+	s := newScriptedGraphQL(t)
+	s.script("SdkGolangClusterWithUpgradesInfo",
+		clusterUpgradeResp(upgradeNodeAtVersion(id, gqlcluster.RSCUpgradeStatusUpgrading, prev)),
+		clusterUpgradeResp(upgradeNodeAtVersion(id, gqlcluster.RSCUpgradeStatusRollingBack, prev)),
+	)
+
+	srv := httptest.NewServer(handler.GraphQL(s.handler()))
+	defer srv.Close()
+
+	_, err := Wrap(newTestClient(srv)).WaitForUpgrade(ctx, id, target)
+	if err == nil {
+		t.Fatal("expected error")
+	}
+	if !strings.Contains(err.Error(), "rolling back") {
+		t.Errorf("error should mention rolling back, got: %v", err)
+	}
+}
+
+func TestWaitForRollbackReachesPreviousVersion(t *testing.T) {
+	shortenPollDelays(t)
+	ctx, cancel := context.WithCancelCause(context.Background())
+	defer assert.Context(t, ctx, cancel)
+
+	id := uuid.MustParse("11111111-1111-1111-1111-111111111111")
+	target := "9.3.3-p8-29908"
+	prev := "9.2.3-p3-29515"
+
+	s := newScriptedGraphQL(t)
+	s.script("SdkGolangClusterWithUpgradesInfo",
+		clusterUpgradeResp(upgradeNodeAtVersion(id, gqlcluster.RSCUpgradeStatusRollingBack, target)),
+		clusterUpgradeResp(upgradeNodeAtVersion(id, gqlcluster.RSCUpgradeStatusRollingBack, target)),
+		clusterUpgradeResp(upgradeNodeAtVersion(id, gqlcluster.RSCUpgradeStatusReadyForUpgrade, prev)),
+	)
+
+	srv := httptest.NewServer(handler.GraphQL(s.handler()))
+	defer srv.Close()
+
+	info, err := Wrap(newTestClient(srv)).WaitForRollback(ctx, id, prev)
+	if err != nil {
+		t.Fatalf("WaitForRollback: %v", err)
+	}
+	if info.Version != prev {
+		t.Errorf("expected installed Version %q, got %q", prev, info.Version)
+	}
+}
+
+func TestWaitForRollbackFailure(t *testing.T) {
+	shortenPollDelays(t)
+	ctx, cancel := context.WithCancelCause(context.Background())
+	defer assert.Context(t, ctx, cancel)
+
+	id := uuid.MustParse("11111111-1111-1111-1111-111111111111")
+
+	s := newScriptedGraphQL(t)
+	s.script("SdkGolangClusterWithUpgradesInfo",
+		clusterUpgradeResp(upgradeNodeAtVersion(id, gqlcluster.RSCUpgradeStatusRollingBack, "9.3.3-p8-29908")),
+		clusterUpgradeResp(upgradeNodeAtVersion(id, gqlcluster.RSCUpgradeStatusRollingBackFailed, "9.3.3-p8-29908")),
+	)
+
+	srv := httptest.NewServer(handler.GraphQL(s.handler()))
+	defer srv.Close()
+
+	_, err := Wrap(newTestClient(srv)).WaitForRollback(ctx, id, "9.2.3-p3-29515")
+	if err == nil {
+		t.Fatal("expected error")
+	}
+	if !strings.Contains(err.Error(), "rollback") || !strings.Contains(err.Error(), "failed") {
+		t.Errorf("error should mention rollback failed, got: %v", err)
+	}
+}

--- a/pkg/polaris/graphql/cluster/queries.go
+++ b/pkg/polaris/graphql/cluster/queries.go
@@ -466,6 +466,28 @@ var startDownloadPackageBatchJobQuery = `mutation SdkGolangStartDownloadPackageB
   }
 }`
 
+// startUpgradeBatchJob GraphQL query
+var startUpgradeBatchJobQuery = `mutation SdkGolangStartUpgradeBatchJob(
+  $listClusterUuid: [UUID!]!
+  $mode: String!
+  $action: ActionType!
+  $version: String!
+  $contextTag: String
+) {
+  result: startUpgradeBatchJob(
+    listClusterUuid: $listClusterUuid
+    mode: $mode
+    action: $action
+    version: $version
+    context_tag: $contextTag
+  ) {
+    upgradeJobReply {
+      message
+      success
+    }
+  }
+}`
+
 // updateClusterNtpServers GraphQL query
 var updateClusterNtpServersQuery = `mutation SdkGolangUpdateClusterNtpServers($input: UpdateClusterNtpServersInput!) {
   result: updateClusterNtpServers(input: $input) {

--- a/pkg/polaris/graphql/cluster/queries/start_upgrade_batch_job.graphql
+++ b/pkg/polaris/graphql/cluster/queries/start_upgrade_batch_job.graphql
@@ -1,0 +1,20 @@
+mutation RubrikPolarisSDKRequest(
+  $listClusterUuid: [UUID!]!
+  $mode: String!
+  $action: ActionType!
+  $version: String!
+  $contextTag: String
+) {
+  result: startUpgradeBatchJob(
+    listClusterUuid: $listClusterUuid
+    mode: $mode
+    action: $action
+    version: $version
+    context_tag: $contextTag
+  ) {
+    upgradeJobReply {
+      message
+      success
+    }
+  }
+}

--- a/pkg/polaris/graphql/cluster/upgrade.go
+++ b/pkg/polaris/graphql/cluster/upgrade.go
@@ -302,6 +302,67 @@ const (
 	UpgradeTypeRolling UpgradeType = "ROLLING"
 )
 
+// ActionType represents the upgrade action.
+type ActionType string
+
+const (
+	ActionResume   ActionType = "RESUME"
+	ActionRollback ActionType = "ROLLBACK"
+	ActionStart    ActionType = "START"
+)
+
+// UpgradeJobReply is the per-cluster reply from startUpgradeBatchJob (and
+// scheduleUpgradeBatchJob). Success=false signals the server rejected the
+// job; Message carries the rejection reason.
+type UpgradeJobReply struct {
+	Message string `json:"message"`
+	Success bool   `json:"success"`
+}
+
+// StartUpgrade kicks off an immediate upgrade for the specified cluster.
+// mode is the upgrade mode (e.g. "normal", "rolling"); action is one of the
+// ActionType constants. contextTag is optional — pass an empty string for the
+// server default.
+func StartUpgrade(ctx context.Context, gql *graphql.Client, clusterID uuid.UUID, mode string, action ActionType, version, contextTag string) (UpgradeJobReply, error) {
+	gql.Log().Print(log.Trace)
+
+	query := startUpgradeBatchJobQuery
+	vars := struct {
+		ListClusterUUID []uuid.UUID `json:"listClusterUuid"`
+		Mode            string      `json:"mode"`
+		Action          ActionType  `json:"action"`
+		Version         string      `json:"version"`
+		ContextTag      *string     `json:"contextTag,omitempty"`
+	}{
+		ListClusterUUID: []uuid.UUID{clusterID},
+		Mode:            mode,
+		Action:          action,
+		Version:         version,
+	}
+	if contextTag != "" {
+		vars.ContextTag = &contextTag
+	}
+	buf, err := gql.Request(ctx, query, vars)
+	if err != nil {
+		return UpgradeJobReply{}, graphql.RequestError(query, err)
+	}
+
+	var payload struct {
+		Data struct {
+			Result []struct {
+				UpgradeJobReply UpgradeJobReply `json:"upgradeJobReply"`
+			} `json:"result"`
+		} `json:"data"`
+	}
+	if err := json.Unmarshal(buf, &payload); err != nil {
+		return UpgradeJobReply{}, graphql.UnmarshalError(query, err)
+	}
+	if len(payload.Data.Result) != 1 {
+		return UpgradeJobReply{}, graphql.ResponseError(query, fmt.Errorf("expected 1 reply, got %d", len(payload.Data.Result)))
+	}
+	return payload.Data.Result[0].UpgradeJobReply, nil
+}
+
 // SetUpgradeTypeReply is returned by setUpgradeType. The JSON tag for
 // Exceptions preserves the schema-level typo ("excepshuns").
 type SetUpgradeTypeReply struct {


### PR DESCRIPTION
# Description

Adds Cluster upgrade API with WaitForUpgrade and WaitForRollback.

WaitForUpgrade polls until the installed Version matches targetVersion
(success), a terminal upgrade failure is observed (UPGRADE_FAILED via
V2, or the V1 equivalents when V2 is absent), or the cluster has decided
to roll back (returned as a wrapped error pointing callers at
WaitForRollback).

WaitForRollback waits through a rollback in progress. When previousVersion
is non-empty, success means the installed Version matches it; otherwise
success means the V2 status has left ROLLINGBACK for any non-failure
state. ROLLINGBACK_FAILED is returned as a wrapped error.

Adds ActionType (START/RESUME/ROLLBACK) and UpgradeJobReply types.

Six state-transition tests cover server-side rejection, successful
upgrade, terminal failure, rolling-back early-return, rollback success,
and rollback failure.

## How Has This Been Tested?

Manual & new unit tests.

## Types of changes

What types of changes does your code introduce? Put an `x` in all the boxes that apply:
- [ ] Bug fix (non-breaking change which fixes an issue)
- [x] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)
- [ ] Other (please describe in the Description above)

## Checklist:

Go over all the following points, and put an `x` in all the boxes that apply. If you're unsure about any of these, don't hesitate to ask. We're here to help!
- [x] My code follows the code style of this project.
- [ ] My change requires a change to the documentation.
- [ ] I have updated the documentation accordingly.
- [ ] I have updated the CHANGELOG file accordingly for the version that this merge modifies.
- [x] I have added tests to cover my changes.
- [x] All new and existing tests passed.
