### PR TITLE
Add NativeResourceGroups for Azure resource group inventory

### DIFF
--- a/pkg/polaris/azure/native_account.go
+++ b/pkg/polaris/azure/native_account.go
@@ -72,3 +72,27 @@ func (a API) NativeSubscriptionByCloudAccountID(ctx context.Context, cloudAccoun
 func (a API) NativeSubscriptions(ctx context.Context, filter string) ([]azure.NativeSubscription, error) {
 	return azure.Wrap(a.client).NativeSubscriptions(ctx, filter)
 }
+
+// NativeResourceGroups returns Azure resource groups visible to RSC,
+// optionally filtered to the given subscription IDs and to those whose name
+// contains nameSubstring. A nil/empty subscription slice returns resource
+// groups across all managed subscriptions; the RSC API requires a non-empty
+// subscription filter, so in that case the list of managed subscriptions is
+// fetched and used as the filter. Passing an empty nameSubstring disables the
+// name filter.
+func (a API) NativeResourceGroups(ctx context.Context, subscriptionIDs []uuid.UUID, nameSubstring string) ([]azure.NativeResourceGroup, error) {
+	if len(subscriptionIDs) == 0 {
+		subs, err := a.NativeSubscriptions(ctx, "")
+		if err != nil {
+			return nil, fmt.Errorf("failed to list native subscriptions: %s", err)
+		}
+		if len(subs) == 0 {
+			return nil, nil
+		}
+		subscriptionIDs = make([]uuid.UUID, 0, len(subs))
+		for _, s := range subs {
+			subscriptionIDs = append(subscriptionIDs, s.ID)
+		}
+	}
+	return azure.Wrap(a.client).NativeResourceGroups(ctx, subscriptionIDs, nameSubstring)
+}

--- a/pkg/polaris/graphql/azure/native.go
+++ b/pkg/polaris/graphql/azure/native.go
@@ -92,6 +92,83 @@ func (a API) NativeSubscriptions(ctx context.Context, filter string) ([]NativeSu
 	return subscriptions, nil
 }
 
+// PathNode is one step in the logical/physical hierarchy path for an RSC
+// inventory object.
+type PathNode struct {
+	FID        string `json:"fid"`
+	Name       string `json:"name"`
+	ObjectType string `json:"objectType"`
+}
+
+// NativeResourceGroup represents an Azure resource group surfaced by RSC.
+type NativeResourceGroup struct {
+	ID           string `json:"id"`
+	Name         string `json:"name"`
+	Subscription struct {
+		ID   string `json:"id"`
+		Name string `json:"name"`
+	} `json:"azureSubscriptionDetails"`
+	SLAAssignment sla.Assignment `json:"slaAssignment"`
+	LogicalPath   []PathNode     `json:"logicalPath"`
+	PhysicalPath  []PathNode     `json:"physicalPath"`
+}
+
+// NativeResourceGroups returns all Azure resource groups visible to RSC,
+// filtered to the given subscription IDs and (optionally) to those whose name
+// contains nameSubstring. The subscription ID list must be non-empty: the
+// server rejects an empty filter; the high-level wrapper in
+// pkg/polaris/azure/native_account.go expands a nil/empty list to all managed
+// subscriptions before calling this method.
+func (a API) NativeResourceGroups(ctx context.Context, subscriptionIDs []uuid.UUID, nameSubstring string) ([]NativeResourceGroup, error) {
+	a.log.Print(log.Trace)
+
+	ids := make([]string, 0, len(subscriptionIDs))
+	for _, id := range subscriptionIDs {
+		ids = append(ids, id.String())
+	}
+
+	var groups []NativeResourceGroup
+	var cursor string
+	for {
+		query := azureNativeResourceGroupsQuery
+		buf, err := a.GQL.Request(ctx, query, struct {
+			After           string   `json:"after,omitempty"`
+			SubscriptionIDs []string `json:"subscriptionIds"`
+			NameSubstring   string   `json:"nameSubstring"`
+		}{After: cursor, SubscriptionIDs: ids, NameSubstring: nameSubstring})
+		if err != nil {
+			return nil, graphql.RequestError(query, err)
+		}
+
+		var payload struct {
+			Data struct {
+				Result struct {
+					Edges []struct {
+						Node NativeResourceGroup `json:"node"`
+					} `json:"edges"`
+					PageInfo struct {
+						EndCursor   string `json:"endCursor"`
+						HasNextPage bool   `json:"hasNextPage"`
+					} `json:"pageInfo"`
+				} `json:"result"`
+			} `json:"data"`
+		}
+		if err := json.Unmarshal(buf, &payload); err != nil {
+			return nil, graphql.UnmarshalError(query, err)
+		}
+		for _, edge := range payload.Data.Result.Edges {
+			groups = append(groups, edge.Node)
+		}
+
+		if !payload.Data.Result.PageInfo.HasNextPage {
+			break
+		}
+		cursor = payload.Data.Result.PageInfo.EndCursor
+	}
+
+	return groups, nil
+}
+
 // Deprecated: no replacement.
 type ProtectionFeature string
 

--- a/pkg/polaris/graphql/azure/native.go
+++ b/pkg/polaris/graphql/azure/native.go
@@ -115,10 +115,8 @@ type NativeResourceGroup struct {
 
 // NativeResourceGroups returns all Azure resource groups visible to RSC,
 // filtered to the given subscription IDs and (optionally) to those whose name
-// contains nameSubstring. The subscription ID list must be non-empty: the
-// server rejects an empty filter; the high-level wrapper in
-// pkg/polaris/azure/native_account.go expands a nil/empty list to all managed
-// subscriptions before calling this method.
+// contains nameSubstring. The subscription ID list must be non-empty; RSC
+// rejects an empty filter.
 func (a API) NativeResourceGroups(ctx context.Context, subscriptionIDs []uuid.UUID, nameSubstring string) ([]NativeResourceGroup, error) {
 	a.log.Print(log.Trace)
 

--- a/pkg/polaris/graphql/azure/queries.go
+++ b/pkg/polaris/graphql/azure/queries.go
@@ -132,10 +132,20 @@ var azureNativeResourceGroupsQuery = `query SdkGolangAzureNativeResourceGroups($
             AZURE_STORAGE_ACCOUNT,
             AZURE_POSTGRES_FLEXIBLE_SERVER
         ]
-        azureNativeProtectionFeatures: [VM, SQL_MI, SQL_DB, BLOB, POSTGRES_FLEXIBLE_SERVER]
+        azureNativeProtectionFeatures: [
+            VM,
+            SQL_MI,
+            SQL_DB,
+            BLOB,
+            POSTGRES_FLEXIBLE_SERVER
+        ]
         commonResourceGroupFilters: {
-            subscriptionFilter: { subscriptionIds: $subscriptionIds }
-            nameSubstringFilter: { nameSubstring: $nameSubstring }
+            subscriptionFilter: {
+                subscriptionIds: $subscriptionIds
+            }
+            nameSubstringFilter: {
+                nameSubstring: $nameSubstring
+            }
         }
     ) {
         edges {

--- a/pkg/polaris/graphql/azure/queries.go
+++ b/pkg/polaris/graphql/azure/queries.go
@@ -120,6 +120,52 @@ var azureCloudAccountPermissionConfigQuery = `query SdkGolangAzureCloudAccountPe
     }
 }`
 
+// azureNativeResourceGroups GraphQL query
+var azureNativeResourceGroupsQuery = `query SdkGolangAzureNativeResourceGroups($after: String, $subscriptionIds: [String!]!, $nameSubstring: String!) {
+    result: azureNativeResourceGroups(
+        after: $after
+        protectedObjectTypes: [
+            AzureNativeVirtualMachine,
+            AzureNativeManagedDisk,
+            AzureSqlDatabaseDb,
+            AzureSqlManagedInstanceDb,
+            AZURE_STORAGE_ACCOUNT,
+            AZURE_POSTGRES_FLEXIBLE_SERVER
+        ]
+        azureNativeProtectionFeatures: [VM, SQL_MI, SQL_DB, BLOB, POSTGRES_FLEXIBLE_SERVER]
+        commonResourceGroupFilters: {
+            subscriptionFilter: { subscriptionIds: $subscriptionIds }
+            nameSubstringFilter: { nameSubstring: $nameSubstring }
+        }
+    ) {
+        edges {
+            node {
+                id
+                name
+                azureSubscriptionDetails {
+                    id
+                    name
+                }
+                slaAssignment
+                logicalPath {
+                    fid
+                    name
+                    objectType
+                }
+                physicalPath {
+                    fid
+                    name
+                    objectType
+                }
+            }
+        }
+        pageInfo {
+            endCursor
+            hasNextPage
+        }
+    }
+}`
+
 // azureNativeSubscriptions GraphQL query
 var azureNativeSubscriptionsQuery = `query SdkGolangAzureNativeSubscriptions($after: String, $filter: String!) {
   result: azureNativeSubscriptions(

--- a/pkg/polaris/graphql/azure/queries/azure_native_resource_groups.graphql
+++ b/pkg/polaris/graphql/azure/queries/azure_native_resource_groups.graphql
@@ -9,10 +9,20 @@ query RubrikPolarisSDKRequest($after: String, $subscriptionIds: [String!]!, $nam
             AZURE_STORAGE_ACCOUNT,
             AZURE_POSTGRES_FLEXIBLE_SERVER
         ]
-        azureNativeProtectionFeatures: [VM, SQL_MI, SQL_DB, BLOB, POSTGRES_FLEXIBLE_SERVER]
+        azureNativeProtectionFeatures: [
+            VM,
+            SQL_MI,
+            SQL_DB,
+            BLOB,
+            POSTGRES_FLEXIBLE_SERVER
+        ]
         commonResourceGroupFilters: {
-            subscriptionFilter: { subscriptionIds: $subscriptionIds }
-            nameSubstringFilter: { nameSubstring: $nameSubstring }
+            subscriptionFilter: {
+                subscriptionIds: $subscriptionIds
+            }
+            nameSubstringFilter: {
+                nameSubstring: $nameSubstring
+            }
         }
     ) {
         edges {

--- a/pkg/polaris/graphql/azure/queries/azure_native_resource_groups.graphql
+++ b/pkg/polaris/graphql/azure/queries/azure_native_resource_groups.graphql
@@ -1,0 +1,44 @@
+query RubrikPolarisSDKRequest($after: String, $subscriptionIds: [String!]!, $nameSubstring: String!) {
+    result: azureNativeResourceGroups(
+        after: $after
+        protectedObjectTypes: [
+            AzureNativeVirtualMachine,
+            AzureNativeManagedDisk,
+            AzureSqlDatabaseDb,
+            AzureSqlManagedInstanceDb,
+            AZURE_STORAGE_ACCOUNT,
+            AZURE_POSTGRES_FLEXIBLE_SERVER
+        ]
+        azureNativeProtectionFeatures: [VM, SQL_MI, SQL_DB, BLOB, POSTGRES_FLEXIBLE_SERVER]
+        commonResourceGroupFilters: {
+            subscriptionFilter: { subscriptionIds: $subscriptionIds }
+            nameSubstringFilter: { nameSubstring: $nameSubstring }
+        }
+    ) {
+        edges {
+            node {
+                id
+                name
+                azureSubscriptionDetails {
+                    id
+                    name
+                }
+                slaAssignment
+                logicalPath {
+                    fid
+                    name
+                    objectType
+                }
+                physicalPath {
+                    fid
+                    name
+                    objectType
+                }
+            }
+        }
+        pageInfo {
+            endCursor
+            hasNextPage
+        }
+    }
+}


### PR DESCRIPTION
## Description

Adds a Go SDK wrapper for the `azureNativeResourceGroups` RSC GraphQL query so
callers can list Azure resource groups that RSC is aware of.

New surface:

- `pkg/polaris/graphql/azure/queries/azure_native_resource_groups.graphql` — the
  paginated query. `protectedObjectTypes` and `azureNativeProtectionFeatures`
  are baked into the `.graphql` file (matching the precedent in
  `azure_native_subscriptions.graphql`) so they are not part of the Go API.
- `pkg/polaris/graphql/azure/native.go` — new `NativeResourceGroup` and
  `PathNode` types and a `NativeResourceGroups(ctx, subscriptionIDs,
  nameSubstring)` method that materialises the cursor-paginated result.
- `pkg/polaris/azure/native_account.go` — high-level wrapper of the same name.
  Expands an empty `subscriptionIDs` slice to all managed subscriptions before
  calling the query, because the server rejects an empty subscription filter.

## Motivation and Context

`terraform-provider-polaris` needs to enumerate Azure resource groups under
RSC-managed subscriptions to power a new data source. There was no existing
SDK entrypoint for the picker query; this PR adds one.

## How Has This Been Tested?

- `go generate ./...`, `go fmt ./...`, `go vet ./...`, `go test ./...` against
  the SDK module — all clean.
- End-to-end verification via the companion provider branch (separate PR
  pending): a `terraform plan` against a live RSC environment returned the
  expected resource group inventory (full list, subscription-filtered list,
  and exact-name lookup), with cursor pagination exercised.

A few non-obvious server behaviours surfaced while wiring this up and are
captured in code/comments:

- `commonResourceGroupFilters.subscriptionFilter.subscriptionIds` is typed
  `[String!]!` — a non-null list of non-null strings, not `[UUID!]`.
- An empty `subscriptionIds` list is rejected at request time
  (`INVALID_ARGUMENT: Filter specification cannot be empty`). The high-level
  wrapper expands "no filter" into the list of managed subscriptions.
- `nameSubstringFilter.nameSubstring` is typed `String!`. The wrapper passes
  the empty string when no name filter is desired; the server treats it as a
  substring of every name.

## Types of changes

- [x] New feature (non-breaking change which adds functionality)

## Checklist

- [x] My code follows the code style of this project.
- [ ] My change requires a change to the documentation.
- [ ] I have updated the documentation accordingly.
- [ ] I have updated the CHANGELOG file accordingly for the version that this merge modifies.
- [ ] I have added tests to cover my changes.
- [x] All new and existing tests passed.