### PR TITLE
Compare CDM versions by trailing build number

### DIFF
--- a/pkg/polaris/cluster/cluster_version.go
+++ b/pkg/polaris/cluster/cluster_version.go
@@ -26,24 +26,25 @@ import (
 )
 
 // CDMVersion represents a parsed CDM version (e.g., "9.4.0-p2-30507").
-// Only the major.minor.patch portion is used for comparisons.
+// Comparisons use the major.minor.patch portion and, as a final tiebreaker,
+// the trailing build number, so releases sharing the same major.minor.patch
+// (e.g. "9.5.0-p1-35914" and "9.5.0-p2-36035") order by build.
 type CDMVersion struct {
 	major int
 	minor int
 	patch int
+	build int
 }
 
 // ParseCDMVersion parses a version string and creates a CDMVersion.
-// It handles formats like "9.4.0", "9.4", "9.4.0-p2-30507".
+// It handles formats like "9.4.0", "9.4", "9.4.0-30189", "9.4.0-p2-30507".
 func ParseCDMVersion(version string) (CDMVersion, error) {
-	// Remove any suffix after the first hyphen (e.g., "-p2-30507")
-	if idx := strings.Index(version, "-"); idx != -1 {
-		version = version[:idx]
-	}
+	// Split the major.minor.patch core from any "-pN-build" suffix.
+	core, _, _ := strings.Cut(version, "-")
 
 	var major, minor, patch int
 	var err error
-	parts := strings.Split(version, ".")
+	parts := strings.Split(core, ".")
 	if len(parts) >= 1 {
 		major, err = strconv.Atoi(parts[0])
 		if err != nil {
@@ -63,7 +64,15 @@ func ParseCDMVersion(version string) (CDMVersion, error) {
 		}
 	}
 
-	return CDMVersion{major: major, minor: minor, patch: patch}, nil
+	// The build number is the final hyphen-separated segment, when numeric
+	// (e.g. "9.4.0-p2-30507" -> 30507, "9.4.0-30189" -> 30189). A version with
+	// no build, such as "9.4.0" or a bare patch level "9.3.3-p9", leaves it at 0.
+	var build int
+	if i := strings.LastIndex(version, "-"); i != -1 {
+		build, _ = strconv.Atoi(version[i+1:])
+	}
+
+	return CDMVersion{major: major, minor: minor, patch: patch, build: build}, nil
 }
 
 // Compare compares the CDM version with another version string.
@@ -73,7 +82,9 @@ func ParseCDMVersion(version string) (CDMVersion, error) {
 //	 0 if v == other
 //	 1 if v > other
 //
-// Only the major.minor.patch portion is compared; suffixes are ignored.
+// The major.minor.patch portion is compared first; the trailing build number
+// breaks ties between versions sharing the same major.minor.patch. Other
+// suffix tokens (such as the "pN" patch level) are not compared.
 func (v CDMVersion) Compare(other string) int {
 	o, err := ParseCDMVersion(other)
 	if err != nil {
@@ -94,6 +105,12 @@ func (v CDMVersion) Compare(other string) int {
 	}
 	if v.patch != o.patch {
 		if v.patch < o.patch {
+			return -1
+		}
+		return 1
+	}
+	if v.build != o.build {
+		if v.build < o.build {
 			return -1
 		}
 		return 1

--- a/pkg/polaris/cluster/cluster_version_test.go
+++ b/pkg/polaris/cluster/cluster_version_test.go
@@ -30,7 +30,8 @@ func TestCDMVersionCompare(t *testing.T) {
 		expected int
 	}{
 		{"equal versions", "9.4.0", "9.4.0", 0},
-		{"equal with suffix", "9.4.0-p2-30507", "9.4.0", 0},
+		{"equal suffix without build", "9.4.0-p2", "9.4.0", 0},
+		{"build greater than base", "9.4.0-p2-30507", "9.4.0", 1},
 		{"less than major", "8.4.0", "9.4.0", -1},
 		{"greater than major", "10.4.0", "9.4.0", 1},
 		{"less than minor", "9.3.0", "9.4.0", -1},
@@ -38,7 +39,10 @@ func TestCDMVersionCompare(t *testing.T) {
 		{"less than patch", "9.4.0", "9.4.1", -1},
 		{"greater than patch", "9.4.2", "9.4.1", 1},
 		{"compare with suffix", "9.4.0-p2-30507", "9.5", -1},
-		{"partial version comparison", "9.5.0-p1-12345", "9.5", 0},
+		{"build breaks same patch tie", "9.5.0-p2-36035", "9.5.0-p1-35914", 1},
+		{"lower build same patch", "9.5.0-p1-35914", "9.5.0-p2-36035", -1},
+		{"equal full version", "9.4.2-p1-30914", "9.4.2-p1-30914", 0},
+		{"build greater than partial", "9.5.0-p1-12345", "9.5", 1},
 		{"major only comparison", "10.0.0", "9", 1},
 	}
 


### PR DESCRIPTION
# Description

Add a build field to CDMVersion, parsed from the trailing numeric token of the version suffix (e.g. 9.4.0-p2-30507 -> 30507, 9.4.0-30189 -> 30189). Compare now uses the build as a final tiebreaker after major.minor.patch, so releases that share the same major.minor.patch order correctly by build (e.g. 9.5.0-p1-35914 < 9.5.0-p2-36035, and 9.4.0 < 9.4.0-p2-30507).

The major.minor.patch comparison still dominates, so minimum-version checks against a major.minor bound are unaffected.

## How Has This Been Tested?

Updated unit tests.

## Types of changes

What types of changes does your code introduce? Put an `x` in all the boxes that apply:
- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)
- [ ] Other (please describe in the Description above)

## Checklist:

Go over all the following points, and put an `x` in all the boxes that apply. If you're unsure about any of these, don't hesitate to ask. We're here to help!
- [x] My code follows the code style of this project.
- [ ] My change requires a change to the documentation.
- [ ] I have updated the documentation accordingly.
- [ ] I have updated the CHANGELOG file accordingly for the version that this merge modifies.
- [x] I have added tests to cover my changes.
- [x] All new and existing tests passed.
