### PR TITLE
Improve support for clearing threshold filters with ForceUpdateThresholdFilter

### DIFF
--- a/pkg/polaris/dspm/policy_test.go
+++ b/pkg/polaris/dspm/policy_test.go
@@ -308,9 +308,24 @@ func TestPolicyManagement(t *testing.T) {
 		t.Errorf("updated Filter.Filters[0].Config.Type: got %q, want %q",
 			policy.Filter.Filters[0].Config.Type, dspm.FilterTypeDocumentExposure)
 	}
-	// The API clears ThresholdFilter when it is omitted from the update.
-	if policy.ThresholdFilter != nil {
-		t.Error("ThresholdFilter: got non-nil after partial update, want nil")
+	// The API preserves ThresholdFilter when it is omitted from the update.
+	if policy.ThresholdFilter == nil {
+		t.Fatal("ThresholdFilter: got nil after partial update, want preserved")
+	}
+	if policy.ThresholdFilter.Op != dspm.LogicalAnd {
+		t.Errorf("preserved ThresholdFilter.Op: got %q, want %q",
+			policy.ThresholdFilter.Op, dspm.LogicalAnd)
+	}
+	if len(policy.ThresholdFilter.Filters) != 1 {
+		t.Fatalf("preserved ThresholdFilter.Filters length: got %d, want 1",
+			len(policy.ThresholdFilter.Filters))
+	}
+	if policy.ThresholdFilter.Filters[0].Config == nil {
+		t.Fatal("preserved ThresholdFilter.Filters[0].Config is nil")
+	}
+	if policy.ThresholdFilter.Filters[0].Config.Type != dspm.FilterTypeDocumentExposure {
+		t.Errorf("preserved ThresholdFilter.Filters[0].Config.Type: got %q, want %q",
+			policy.ThresholdFilter.Filters[0].Config.Type, dspm.FilterTypeDocumentExposure)
 	}
 
 	// Disable the policy.
@@ -329,6 +344,118 @@ func TestPolicyManagement(t *testing.T) {
 	}
 	if policy.Enabled {
 		t.Error("Enabled after disable: got true, want false")
+	}
+}
+
+// TestPolicyRemoveThresholdFilter verifies that an existing threshold filter
+// can be removed from a policy. Omitting the threshold filter from an update
+// preserves it (see TestPolicyManagement), so removal is requested explicitly
+// by sending an empty threshold filter group.
+func TestPolicyRemoveThresholdFilter(t *testing.T) {
+	ctx := context.Background()
+
+	if !testsetup.BoolEnvSet("TEST_INTEGRATION") {
+		t.Skipf("skipping due to env TEST_INTEGRATION not set")
+	}
+
+	dspmClient := Wrap(client)
+
+	// Discover valid filter values so the test uses values the API accepts.
+	sensMeta, err := dspmClient.FilterValues(ctx, dspm.FilterTypeDocumentSensitivity, "")
+	if err != nil {
+		t.Fatalf("failed to discover sensitivity filter values: %v", err)
+	}
+	if len(sensMeta.Values) == 0 {
+		t.Fatal("no values returned for sensitivity filter")
+	}
+	sensValue := sensMeta.Values[0].ID
+
+	exposureMeta, err := dspmClient.FilterValues(ctx, dspm.FilterTypeDocumentExposure, "")
+	if err != nil {
+		t.Fatalf("failed to discover exposure filter values: %v", err)
+	}
+	if len(exposureMeta.Values) == 0 {
+		t.Fatal("no values returned for exposure filter")
+	}
+	exposureValue := exposureMeta.Values[0].ID
+
+	// Create a policy with a threshold filter.
+	thresholdFilter := dspm.GroupConfig{
+		Op: dspm.LogicalAnd,
+		Filters: []dspm.Node{
+			{
+				Config: &dspm.Config{
+					Type:         dspm.FilterTypeDocumentExposure,
+					Values:       []string{exposureValue},
+					Relationship: dspm.RelIs,
+				},
+			},
+		},
+	}
+	policyID, err := dspmClient.CreatePolicy(ctx, dspm.CreateInput{
+		Name:        "SDK Integration Test Policy Threshold Removal",
+		Description: "Created by SDK integration test",
+		Category:    dspm.CategoryOverexposed,
+		Severity:    dspm.SeverityHigh,
+		Filter: dspm.GroupConfig{
+			Op: dspm.LogicalAnd,
+			Filters: []dspm.Node{
+				{
+					Config: &dspm.Config{
+						Type:         dspm.FilterTypeDocumentSensitivity,
+						Values:       []string{sensValue},
+						Relationship: dspm.RelIs,
+					},
+				},
+			},
+		},
+		ThresholdFilter: &thresholdFilter,
+	})
+	if err != nil {
+		t.Fatal(err)
+	}
+	t.Cleanup(func() {
+		if err := dspmClient.DeletePolicy(ctx, policyID); err != nil {
+			t.Errorf("failed to delete policy: %v", err)
+		}
+	})
+
+	// Confirm the threshold filter was set on creation.
+	policy, err := dspmClient.PolicyByID(ctx, policyID)
+	if err != nil {
+		t.Fatal(err)
+	}
+	if policy.ThresholdFilter == nil {
+		t.Fatal("ThresholdFilter is nil after create, want set")
+	}
+
+	// Remove the threshold filter via the force-update sentinel. Omitting the
+	// threshold filter leaves it alone; ForceUpdateThresholdFilter with a nil
+	// threshold filter omits the field and tells the API to clear the stored
+	// value.
+	err = dspmClient.UpdatePolicy(ctx, dspm.UpdateInput{
+		ID:                         policyID,
+		ForceUpdateThresholdFilter: true,
+	})
+	if err != nil {
+		t.Fatal(err)
+	}
+
+	// Verify the threshold filter was removed.
+	policy, err = dspmClient.PolicyByID(ctx, policyID)
+	if err != nil {
+		t.Fatal(err)
+	}
+	if policy.ThresholdFilter != nil {
+		t.Error("ThresholdFilter: got non-nil after explicit removal, want nil")
+	}
+
+	// The primary filter must be unaffected by the threshold filter removal.
+	if policy.Filter == nil {
+		t.Fatal("Filter is nil after threshold filter removal")
+	}
+	if len(policy.Filter.Filters) != 1 {
+		t.Errorf("Filter.Filters length: got %d, want 1", len(policy.Filter.Filters))
 	}
 }
 

--- a/pkg/polaris/graphql/dspm/policy.go
+++ b/pkg/polaris/graphql/dspm/policy.go
@@ -321,15 +321,27 @@ type CreateInput struct {
 }
 
 // UpdateInput holds the parameters for updating a data security policy.
+//
+// The threshold filter is three-state, disambiguated by
+// ForceUpdateThresholdFilter because the API cannot otherwise distinguish
+// "omitted, leave alone" from "explicitly cleared":
+//
+//   - ThresholdFilter set: overwrites the existing value.
+//   - ThresholdFilter nil, ForceUpdateThresholdFilter false: leaves the
+//     existing value alone.
+//   - ThresholdFilter nil, ForceUpdateThresholdFilter true: explicitly clears
+//     it (thresholdFilter is omitted from the request and the force flag tells
+//     the API to clear the stored value).
 type UpdateInput struct {
-	ID              uuid.UUID    `json:"policyId"`
-	Name            *string      `json:"policyName,omitempty"`
-	Description     *string      `json:"description,omitempty"`
-	Category        *Category    `json:"policyCategory,omitempty"`
-	Severity        *Severity    `json:"policySeverity,omitempty"`
-	Enabled         *bool        `json:"isEnabled,omitempty"`
-	Filter          *GroupConfig `json:"filter,omitempty"`
-	ThresholdFilter *GroupConfig `json:"thresholdFilter,omitempty"`
+	ID                         uuid.UUID    `json:"policyId"`
+	Name                       *string      `json:"policyName,omitempty"`
+	Description                *string      `json:"description,omitempty"`
+	Category                   *Category    `json:"policyCategory,omitempty"`
+	Severity                   *Severity    `json:"policySeverity,omitempty"`
+	Enabled                    *bool        `json:"isEnabled,omitempty"`
+	Filter                     *GroupConfig `json:"filter,omitempty"`
+	ThresholdFilter            *GroupConfig `json:"thresholdFilter,omitempty"`
+	ForceUpdateThresholdFilter bool         `json:"forceUpdateThresholdFilter,omitempty"`
 }
 
 // policyTypeDataGov is the RSC policy type for data governance security

--- a/pkg/polaris/graphql/dspm/policy_test.go
+++ b/pkg/polaris/graphql/dspm/policy_test.go
@@ -196,10 +196,36 @@ func TestUpdateInputMarshalJSON(t *testing.T) {
 	}
 
 	// Unset fields should be omitted.
-	for _, key := range []string{"description", "policyCategory", "policySeverity", "filter", "thresholdFilter"} {
+	for _, key := range []string{"description", "policyCategory", "policySeverity", "filter", "thresholdFilter", "forceUpdateThresholdFilter"} {
 		if _, ok := raw[key]; ok {
 			t.Errorf("field %q should be omitted when nil", key)
 		}
+	}
+}
+
+func TestUpdateInputForceUpdateThresholdFilterMarshalJSON(t *testing.T) {
+	input := UpdateInput{
+		ID:                         uuid.MustParse("d4e5f6a7-b8c9-0123-4567-89abcdef0123"),
+		ForceUpdateThresholdFilter: true,
+	}
+
+	data, err := json.Marshal(input)
+	if err != nil {
+		t.Fatalf("failed to marshal UpdateInput: %v", err)
+	}
+
+	var raw map[string]json.RawMessage
+	if err := json.Unmarshal(data, &raw); err != nil {
+		t.Fatalf("failed to unmarshal to map: %v", err)
+	}
+
+	// forceUpdateThresholdFilter is sent and thresholdFilter is omitted: the
+	// nil threshold filter is honored as-is, clearing the existing value.
+	if got, ok := raw["forceUpdateThresholdFilter"]; !ok || string(got) != "true" {
+		t.Errorf("forceUpdateThresholdFilter: got %q (present=%t), want true", got, ok)
+	}
+	if _, ok := raw["thresholdFilter"]; ok {
+		t.Error("thresholdFilter should be omitted when nil")
 	}
 }
 


### PR DESCRIPTION
# Description

The RSC backend now preserves a policy's existing threshold filter when it's omitted from an update (previously it could be cleared on partial update). In addition, UpdateInput gained a flag that gives callers an explicit way to clear a threshold filter.

## How Has This Been Tested?

New & updated tests.

## Types of changes

What types of changes does your code introduce? Put an `x` in all the boxes that apply:
- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)
- [ ] Other (please describe in the Description above)

## Checklist:

Go over all the following points, and put an `x` in all the boxes that apply. If you're unsure about any of these, don't hesitate to ask. We're here to help!
- [x] My code follows the code style of this project.
- [ ] My change requires a change to the documentation.
- [ ] I have updated the documentation accordingly.
- [ ] I have updated the CHANGELOG file accordingly for the version that this merge modifies.
- [x] I have added tests to cover my changes.
- [x] All new and existing tests passed.
