### PR TITLE
Extend AllPermissionsGroupsByFeature with scoped permissions for Azure

### DIFF
--- a/pkg/polaris/graphql/azure/permission_groups.go
+++ b/pkg/polaris/graphql/azure/permission_groups.go
@@ -29,10 +29,32 @@ import (
 	"github.com/rubrikinc/rubrik-polaris-sdk-for-go/pkg/polaris/log"
 )
 
-// PermissionGroupInfo holds information about a permission group.
+// AzureActionWithUseCase represents an Azure RBAC permission with the use
+// case that requires it.
+type AzureActionWithUseCase struct {
+	Permission string `json:"permission"`
+	UseCase    string `json:"useCase"`
+}
+
+// ScopePermissions represents the actions and data actions required at one
+// Azure RBAC scope (subscription or resource group) for a permission group.
+// Azure RBAC distinguishes management-plane operations (actions) from
+// data-plane operations (data actions); both are surfaced separately.
+type ScopePermissions struct {
+	IncludedActionsWithUseCase     []AzureActionWithUseCase `json:"includedActionsWithUseCase"`
+	IncludedDataActionsWithUseCase []AzureActionWithUseCase `json:"includedDataActionsWithUseCase"`
+}
+
+// PermissionGroupInfo holds information about a permission group, including
+// the actions and data actions required at the subscription and resource
+// group scopes. SubscriptionPermissions and ResourceGroupPermissions are
+// lists on the wire even though RSC currently returns exactly one element
+// in each — callers must iterate.
 type PermissionGroupInfo struct {
-	PermissionGroup core.PermissionGroup `json:"permissionsGroup"`
-	Version         int                  `json:"version"`
+	PermissionGroup          core.PermissionGroup `json:"permissionsGroup"`
+	Version                  int                  `json:"version"`
+	SubscriptionPermissions  []ScopePermissions   `json:"subscriptionPermissions"`
+	ResourceGroupPermissions []ScopePermissions   `json:"resourceGroupPermissions"`
 }
 
 // FeaturePermissionGroups holds the permission groups for a feature.

--- a/pkg/polaris/graphql/azure/queries.go
+++ b/pkg/polaris/graphql/azure/queries.go
@@ -93,6 +93,26 @@ var allAzureLatestPermissionsByPermissionsGroupQuery = `query SdkGolangAllAzureL
         permissionsGroupPermissions {
             permissionsGroup
             version
+            subscriptionPermissions {
+                includedActionsWithUseCase {
+                    permission
+                    useCase
+                }
+                includedDataActionsWithUseCase {
+                    permission
+                    useCase
+                }
+            }
+            resourceGroupPermissions {
+                includedActionsWithUseCase {
+                    permission
+                    useCase
+                }
+                includedDataActionsWithUseCase {
+                    permission
+                    useCase
+                }
+            }
         }
     }
 }`

--- a/pkg/polaris/graphql/azure/queries/all_azure_latest_permissions_by_permissions_group.graphql
+++ b/pkg/polaris/graphql/azure/queries/all_azure_latest_permissions_by_permissions_group.graphql
@@ -4,7 +4,26 @@ query RubrikPolarisSDKRequest($features: [CloudAccountFeature!]!) {
         permissionsGroupPermissions {
             permissionsGroup
             version
+            subscriptionPermissions {
+                includedActionsWithUseCase {
+                    permission
+                    useCase
+                }
+                includedDataActionsWithUseCase {
+                    permission
+                    useCase
+                }
+            }
+            resourceGroupPermissions {
+                includedActionsWithUseCase {
+                    permission
+                    useCase
+                }
+                includedDataActionsWithUseCase {
+                    permission
+                    useCase
+                }
+            }
         }
     }
 }
-


### PR DESCRIPTION
# Description

Extends the existing Azure `AllPermissionsGroupsByFeature` catalog lookup
to also surface the subscription- and resource-group-scoped actions and
data actions that each permission group requires. Backs the upcoming
`polaris_azure_permission_groups` / `rubrik_azure_permission_groups`
Terraform data sources, which need to expose the full catalog at plan
time so configurations don't have to hard-code it.

The Azure response is richer than the AWS equivalent (#371):

- Permissions are split across two Azure RBAC scopes,
  `subscriptionPermissions` and `resourceGroupPermissions`.
- Each scope keeps `actions` (management plane) and `dataActions` (data
  plane) separate, per Azure RBAC's standard distinction.
- `subscriptionPermissions` and `resourceGroupPermissions` are
  list-typed on the wire (`AzureCloudAccountRolePermission[]`) — RSC
  currently returns one element in each list, but the Go types are
  slices so callers iterate correctly if that changes.

Done as an extension of the existing wrapper rather than a parallel one
(per review feedback that the original two-files-two-methods shape
duplicated `permission_groups.go`). The single `.graphql` file, single
method, and single type set now carry the new fields. Existing callers
of `AllPermissionsGroupsByFeature` (the `polaris_account` /
`rubrik_account` data source in both providers) keep working unchanged
— Go's JSON unmarshaler ignores `SubscriptionPermissions` /
`ResourceGroupPermissions` when the caller doesn't read them.

## Motivation and Context

Azure counterpart to the AWS data source shipped via
`terraform-provider-rubrik#23` (which used #371). Lets configurations
discover the permission catalog at plan time instead of having to
hard-code the per-feature `BASIC` / `RECOVERY` / etc. split.

## How Has This Been Tested?

- `go build ./...`, `go vet ./...`, `gofmt -l .`, `go generate ./...`
  (idempotent), `go test ./pkg/polaris/graphql/azure/...` — all clean.
- Verified the Go types against a real-API sample for the 14 features
  RSC supports (CLOUD_DISCOVERY, CLOUD_NATIVE_PROTECTION, the two
  AZURE_SQL_*_PROTECTION, CLOUD_NATIVE_BLOB_PROTECTION, EXOCOMPUTE,
  SERVERS_AND_APPS, DSPM_METADATA, DSPM_DATA, CLOUD_NATIVE_ARCHIVAL,
  LAMINAR_TARGET_*, CYBERRECOVERY_*).
- End-to-end exercise will happen on the Terraform provider PR that
  pins this SDK commit.

## Types of changes

- [x] New feature (non-breaking change which adds functionality)

## Checklist

- [x] My code follows the code style of this project.
- [x] My change requires a change to the documentation.
- [x] I have updated the documentation accordingly.
- [x] I have updated the CHANGELOG file accordingly for the version that this merge modifies.
- [ ] I have added tests to cover my changes.
- [x] All new and existing tests passed.

Notes on the unchecked items:

- No unit test added — the AWS counterpart (#371) shipped without one,
  and the integration test for this method lives in the Terraform
  provider PR that pins the SDK commit. Happy to add a Go-level test if
  preferred.
