### PR TITLE
Add typed constants for cluster view permissions

### DIFF
--- a/pkg/polaris/access/role_test.go
+++ b/pkg/polaris/access/role_test.go
@@ -21,16 +21,18 @@
 package access
 
 import (
+	"cmp"
 	"context"
 	"errors"
 	"reflect"
-	"sort"
+	"slices"
 	"testing"
 
 	"github.com/google/uuid"
 	"github.com/rubrikinc/rubrik-polaris-sdk-for-go/internal/testsetup"
 	"github.com/rubrikinc/rubrik-polaris-sdk-for-go/pkg/polaris/graphql"
 	gqlaccess "github.com/rubrikinc/rubrik-polaris-sdk-for-go/pkg/polaris/graphql/access"
+	"github.com/rubrikinc/rubrik-polaris-sdk-for-go/pkg/polaris/graphql/hierarchy"
 )
 
 func TestRoleManagement(t *testing.T) {
@@ -44,10 +46,18 @@ func TestRoleManagement(t *testing.T) {
 
 	// Create role.
 	roleID, err := accessClient.CreateRole(ctx, "Integration Test Role", "Test Role Description", []gqlaccess.Permission{{
-		Operation: "VIEW_CLUSTER",
+		Operation: string(gqlaccess.OperationViewCluster),
 		ObjectsForHierarchyTypes: []gqlaccess.ObjectsForHierarchyType{{
 			SnappableType: "AllSubHierarchyType",
-			ObjectIDs:     []string{"CLUSTER_ROOT"},
+			ObjectIDs:     []string{hierarchy.ClusterRoot},
+		}},
+	}, {
+		// RSC grants VIEW_CLUSTER_REFERENCE automatically with VIEW_CLUSTER, so
+		// grant it explicitly to keep the role free of drift.
+		Operation: string(gqlaccess.OperationViewClusterReference),
+		ObjectsForHierarchyTypes: []gqlaccess.ObjectsForHierarchyType{{
+			SnappableType: "AllSubHierarchyType",
+			ObjectIDs:     []string{hierarchy.ClusterRoot},
 		}},
 	}})
 	if err != nil {
@@ -71,11 +81,17 @@ func TestRoleManagement(t *testing.T) {
 	if role.IsOrgAdmin {
 		t.Error("is org admin is true")
 	}
-	if !reflect.DeepEqual(role.AssignedPermissions, []gqlaccess.Permission{{
-		Operation: "VIEW_CLUSTER",
+	if !reflect.DeepEqual(sortPermissions(role.AssignedPermissions), []gqlaccess.Permission{{
+		Operation: string(gqlaccess.OperationViewCluster),
 		ObjectsForHierarchyTypes: []gqlaccess.ObjectsForHierarchyType{{
 			SnappableType: "AllSubHierarchyType",
-			ObjectIDs:     []string{"CLUSTER_ROOT"},
+			ObjectIDs:     []string{hierarchy.ClusterRoot},
+		}},
+	}, {
+		Operation: string(gqlaccess.OperationViewClusterReference),
+		ObjectsForHierarchyTypes: []gqlaccess.ObjectsForHierarchyType{{
+			SnappableType: "AllSubHierarchyType",
+			ObjectIDs:     []string{hierarchy.ClusterRoot},
 		}},
 	}}) {
 		t.Errorf("invalid role permissions: %s", role.AssignedPermissions)
@@ -104,11 +120,17 @@ func TestRoleManagement(t *testing.T) {
 	if role.IsOrgAdmin {
 		t.Error("is org admin is true")
 	}
-	if !reflect.DeepEqual(role.AssignedPermissions, []gqlaccess.Permission{{
-		Operation: "VIEW_CLUSTER",
+	if !reflect.DeepEqual(sortPermissions(role.AssignedPermissions), []gqlaccess.Permission{{
+		Operation: string(gqlaccess.OperationViewCluster),
 		ObjectsForHierarchyTypes: []gqlaccess.ObjectsForHierarchyType{{
 			SnappableType: "AllSubHierarchyType",
-			ObjectIDs:     []string{"CLUSTER_ROOT"},
+			ObjectIDs:     []string{hierarchy.ClusterRoot},
+		}},
+	}, {
+		Operation: string(gqlaccess.OperationViewClusterReference),
+		ObjectsForHierarchyTypes: []gqlaccess.ObjectsForHierarchyType{{
+			SnappableType: "AllSubHierarchyType",
+			ObjectIDs:     []string{hierarchy.ClusterRoot},
 		}},
 	}}) {
 		t.Errorf("invalid role permissions: %s", role.AssignedPermissions)
@@ -122,16 +144,22 @@ func TestRoleManagement(t *testing.T) {
 
 	// Update role.
 	err = accessClient.UpdateRole(ctx, roleID, "Integration Test Role Updated", "Test Role Description Updated", []gqlaccess.Permission{{
-		Operation: "VIEW_CLUSTER",
+		Operation: string(gqlaccess.OperationViewCluster),
 		ObjectsForHierarchyTypes: []gqlaccess.ObjectsForHierarchyType{{
 			SnappableType: "AllSubHierarchyType",
-			ObjectIDs:     []string{"CLUSTER_ROOT"},
+			ObjectIDs:     []string{hierarchy.ClusterRoot},
+		}},
+	}, {
+		Operation: string(gqlaccess.OperationViewClusterReference),
+		ObjectsForHierarchyTypes: []gqlaccess.ObjectsForHierarchyType{{
+			SnappableType: "AllSubHierarchyType",
+			ObjectIDs:     []string{hierarchy.ClusterRoot},
 		}},
 	}, {
 		Operation: "REMOVE_CLUSTER",
 		ObjectsForHierarchyTypes: []gqlaccess.ObjectsForHierarchyType{{
 			SnappableType: "AllSubHierarchyType",
-			ObjectIDs:     []string{"CLUSTER_ROOT"},
+			ObjectIDs:     []string{hierarchy.ClusterRoot},
 		}},
 	}})
 	if err != nil {
@@ -160,24 +188,26 @@ func TestRoleManagement(t *testing.T) {
 	}
 
 	// Sort permissions in ascending order before asserting.
-	permissions := roles[0].AssignedPermissions
-	sort.Slice(permissions, func(i, j int) bool {
-		return permissions[i].Operation < permissions[j].Operation
-	})
-	if !reflect.DeepEqual(permissions, []gqlaccess.Permission{{
+	if !reflect.DeepEqual(sortPermissions(roles[0].AssignedPermissions), []gqlaccess.Permission{{
 		Operation: "REMOVE_CLUSTER",
 		ObjectsForHierarchyTypes: []gqlaccess.ObjectsForHierarchyType{{
 			SnappableType: "AllSubHierarchyType",
-			ObjectIDs:     []string{"CLUSTER_ROOT"},
+			ObjectIDs:     []string{hierarchy.ClusterRoot},
 		}},
 	}, {
-		Operation: "VIEW_CLUSTER",
+		Operation: string(gqlaccess.OperationViewCluster),
 		ObjectsForHierarchyTypes: []gqlaccess.ObjectsForHierarchyType{{
 			SnappableType: "AllSubHierarchyType",
-			ObjectIDs:     []string{"CLUSTER_ROOT"},
+			ObjectIDs:     []string{hierarchy.ClusterRoot},
+		}},
+	}, {
+		Operation: string(gqlaccess.OperationViewClusterReference),
+		ObjectsForHierarchyTypes: []gqlaccess.ObjectsForHierarchyType{{
+			SnappableType: "AllSubHierarchyType",
+			ObjectIDs:     []string{hierarchy.ClusterRoot},
 		}},
 	}}) {
-		t.Errorf("invalid role permissions: %#v", permissions)
+		t.Errorf("invalid role permissions: %#v", roles[0].AssignedPermissions)
 	}
 
 	// Remove role.
@@ -189,4 +219,13 @@ func TestRoleManagement(t *testing.T) {
 	if _, err = accessClient.RoleByID(ctx, roleID); err == nil || !errors.Is(err, graphql.ErrNotFound) {
 		t.Fatal("role should have been removed")
 	}
+}
+
+// sortPermissions sorts permissions by operation in ascending order.
+func sortPermissions(permissions []gqlaccess.Permission) []gqlaccess.Permission {
+	slices.SortFunc(permissions, func(a, b gqlaccess.Permission) int {
+		return cmp.Compare(a.Operation, b.Operation)
+	})
+
+	return permissions
 }

--- a/pkg/polaris/access/template_test.go
+++ b/pkg/polaris/access/template_test.go
@@ -29,6 +29,7 @@ import (
 	"github.com/google/uuid"
 	"github.com/rubrikinc/rubrik-polaris-sdk-for-go/internal/testsetup"
 	gqlaccess "github.com/rubrikinc/rubrik-polaris-sdk-for-go/pkg/polaris/graphql/access"
+	"github.com/rubrikinc/rubrik-polaris-sdk-for-go/pkg/polaris/graphql/hierarchy"
 )
 
 func TestRoleTemplates(t *testing.T) {
@@ -63,13 +64,13 @@ func TestRoleTemplates(t *testing.T) {
 		Operation: "EXPORT_DATA_CLASS_GLOBAL",
 		ObjectsForHierarchyTypes: []gqlaccess.ObjectsForHierarchyType{{
 			SnappableType: "AllSubHierarchyType",
-			ObjectIDs:     []string{"GlobalResource"},
+			ObjectIDs:     []string{hierarchy.GlobalResource},
 		}},
 	}, {
 		Operation: "VIEW_DATA_CLASS_GLOBAL",
 		ObjectsForHierarchyTypes: []gqlaccess.ObjectsForHierarchyType{{
 			SnappableType: "AllSubHierarchyType",
-			ObjectIDs:     []string{"GlobalResource"},
+			ObjectIDs:     []string{hierarchy.GlobalResource},
 		}},
 	}}) {
 		t.Errorf("invalid role template permissions: %#v", permissions)
@@ -104,19 +105,19 @@ func TestRoleTemplates(t *testing.T) {
 		Operation: "CONFIGURE_DATA_CLASS_GLOBAL",
 		ObjectsForHierarchyTypes: []gqlaccess.ObjectsForHierarchyType{{
 			SnappableType: "AllSubHierarchyType",
-			ObjectIDs:     []string{"GlobalResource"},
+			ObjectIDs:     []string{hierarchy.GlobalResource},
 		}},
 	}, {
 		Operation: "EXPORT_DATA_CLASS_GLOBAL",
 		ObjectsForHierarchyTypes: []gqlaccess.ObjectsForHierarchyType{{
 			SnappableType: "AllSubHierarchyType",
-			ObjectIDs:     []string{"GlobalResource"},
+			ObjectIDs:     []string{hierarchy.GlobalResource},
 		}},
 	}, {
 		Operation: "VIEW_DATA_CLASS_GLOBAL",
 		ObjectsForHierarchyTypes: []gqlaccess.ObjectsForHierarchyType{{
 			SnappableType: "AllSubHierarchyType",
-			ObjectIDs:     []string{"GlobalResource"},
+			ObjectIDs:     []string{hierarchy.GlobalResource},
 		}},
 	}}) {
 		t.Errorf("invalid role template permissions: %#v", permissions)

--- a/pkg/polaris/access/user_test.go
+++ b/pkg/polaris/access/user_test.go
@@ -29,6 +29,7 @@ import (
 	"github.com/rubrikinc/rubrik-polaris-sdk-for-go/internal/testsetup"
 	"github.com/rubrikinc/rubrik-polaris-sdk-for-go/pkg/polaris/graphql"
 	gqlaccess "github.com/rubrikinc/rubrik-polaris-sdk-for-go/pkg/polaris/graphql/access"
+	"github.com/rubrikinc/rubrik-polaris-sdk-for-go/pkg/polaris/graphql/hierarchy"
 )
 
 func TestUserManagement(t *testing.T) {
@@ -114,10 +115,10 @@ func TestUserManagement(t *testing.T) {
 
 	// Add new role.
 	roleID, err := accessClient.CreateRole(ctx, "Integration Test Role", "Test Role Description", []gqlaccess.Permission{{
-		Operation: "VIEW_CLUSTER",
+		Operation: string(gqlaccess.OperationViewCluster),
 		ObjectsForHierarchyTypes: []gqlaccess.ObjectsForHierarchyType{{
 			SnappableType: "AllSubHierarchyType",
-			ObjectIDs:     []string{"CLUSTER_ROOT"},
+			ObjectIDs:     []string{hierarchy.ClusterRoot},
 		}},
 	}})
 	if err != nil {

--- a/pkg/polaris/graphql/access/operation.go
+++ b/pkg/polaris/graphql/access/operation.go
@@ -1,0 +1,36 @@
+// Copyright 2026 Rubrik, Inc.
+//
+// Permission is hereby granted, free of charge, to any person obtaining a copy
+// of this software and associated documentation files (the "Software"), to
+// deal in the Software without restriction, including without limitation the
+// rights to use, copy, modify, merge, publish, distribute, sublicense, and/or
+// sell copies of the Software, and to permit persons to whom the Software is
+// furnished to do so, subject to the following conditions:
+//
+// The above copyright notice and this permission notice shall be included in
+// all copies or substantial portions of the Software.
+//
+// THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+// IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+// FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+// AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+// LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING
+// FROM, OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER
+// DEALINGS IN THE SOFTWARE.
+
+package access
+
+// Operation represents an RSC role permission operation.
+type Operation string
+
+const (
+	// OperationViewCluster grants visibility of clusters. RSC automatically
+	// grants OperationViewClusterReference alongside it, so the two must always
+	// be granted together.
+	OperationViewCluster Operation = "VIEW_CLUSTER"
+
+	// OperationViewClusterReference grants visibility of cluster references. RSC
+	// automatically grants this alongside OperationViewCluster, so the two must
+	// always be granted together.
+	OperationViewClusterReference Operation = "VIEW_CLUSTER_REFERENCE"
+)

--- a/pkg/polaris/graphql/hierarchy/hierarchy.go
+++ b/pkg/polaris/graphql/hierarchy/hierarchy.go
@@ -46,6 +46,16 @@ func Wrap(gql *graphql.Client) API {
 	return API{GQL: gql, log: gql.Log()}
 }
 
+// Well-known hierarchy root node identifiers. These are used as object IDs when
+// scoping operations to a hierarchy root, for example in role permissions.
+const (
+	// ClusterRoot is the root node of the cluster hierarchy.
+	ClusterRoot = "CLUSTER_ROOT"
+
+	// GlobalResource is the root node of the entire managed hierarchy.
+	GlobalResource = "GlobalResource"
+)
+
 // ObjectType represents the type of a hierarchy object.
 type ObjectType string
 


### PR DESCRIPTION
# Description

Introduces a typed `Operation` type with `OperationViewCluster` and `OperationViewClusterReference` constants in the `graphql/access` package, plus `ClusterRoot` and `GlobalResource` hierarchy root-node constants in the `graphql/hierarchy` package. The access integration tests are updated to use these constants instead of bare string literals, and the role tests now grant `VIEW_CLUSTER_REFERENCE` alongside `VIEW_CLUSTER`.

## Motivation and Context

RSC automatically grants `VIEW_CLUSTER_REFERENCE` whenever `VIEW_CLUSTER` is granted. Previously the tests only requested `VIEW_CLUSTER`, so the role read back from RSC carried an extra permission the test did not assert, masking drift. Exposing both operations as typed constants (and the hierarchy roots as named constants) lets callers grant the pair together and stop hard-coding string literals that the compiler cannot check.

## How Has This Been Tested?

Ran the `access` package integration tests against an RSC tenant (`TEST_INTEGRATION=1`): `TestRoleManagement`, `TestRoleTemplates`, and `TestUserManagement` all pass. `go build ./...` and `go vet ./...` are clean on the affected packages.

## Screenshots (if appropriate):

## Types of changes

What types of changes does your code introduce? Put an `x` in all the boxes that apply:
- [ ] Bug fix (non-breaking change which fixes an issue)
- [x] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)
- [ ] Other (please describe in the Description above)

## Checklist:

Go over all the following points, and put an `x` in all the boxes that apply. If you're unsure about any of these, don't hesitate to ask. We're here to help!
- [x] My code follows the code style of this project.
- [ ] My change requires a change to the documentation.
- [ ] I have updated the documentation accordingly.
- [ ] I have updated the CHANGELOG file accordingly for the version that this merge modifies.
- [x] I have added tests to cover my changes.
- [x] All new and existing tests passed.
