### PR TITLE
Add GCP Cloud Cluster (CCES) support

### DIFF
--- a/pkg/polaris/cloudcluster/cloudcluster.go
+++ b/pkg/polaris/cloudcluster/cloudcluster.go
@@ -35,6 +35,7 @@ import (
 	"github.com/rubrikinc/rubrik-polaris-sdk-for-go/pkg/polaris/azure"
 	polcluster "github.com/rubrikinc/rubrik-polaris-sdk-for-go/pkg/polaris/cluster"
 	"github.com/rubrikinc/rubrik-polaris-sdk-for-go/pkg/polaris/event"
+	polgcp "github.com/rubrikinc/rubrik-polaris-sdk-for-go/pkg/polaris/gcp"
 	"github.com/rubrikinc/rubrik-polaris-sdk-for-go/pkg/polaris/graphql"
 	"github.com/rubrikinc/rubrik-polaris-sdk-for-go/pkg/polaris/graphql/cloudcluster"
 	"github.com/rubrikinc/rubrik-polaris-sdk-for-go/pkg/polaris/graphql/core"
@@ -355,6 +356,106 @@ func (a API) CreateAzureCloudCluster(ctx context.Context, input cloudcluster.Cre
 	}
 
 	return cluster, nil
+}
+
+// CreateGcpCloudCluster creates a GCP Cloud Cluster with the specified configuration.
+// It validates the cloud account, CDM version, and cluster input before creating the
+// cluster. Returns the created cluster details after monitoring the creation process.
+func (a API) CreateGcpCloudCluster(ctx context.Context, input cloudcluster.CreateGcpClusterInput, useLatestCdmVersion bool) (cluster CloudCluster, err error) {
+	a.log.Print(log.Trace)
+
+	// Validate Cloud Account exists and has Server and Apps feature
+	gcpClient := polgcp.WrapGQL(a.client)
+	account, err := gcpClient.ProjectByID(ctx, input.CloudAccountID)
+	if err != nil {
+		return CloudCluster{}, err
+	}
+
+	if _, ok := account.Feature(core.FeatureServerAndApps); !ok {
+		return CloudCluster{}, fmt.Errorf("account %q missing feature %s", account.ID, core.FeatureServerAndApps.Name)
+	}
+
+	// Get available CDM versions
+	cdmVersions, err := cloudcluster.Wrap(a.client).AllGcpCdmVersions(ctx, input.CloudAccountID)
+	if err != nil {
+		return CloudCluster{}, fmt.Errorf("failed to get cdm versions: %s", err)
+	}
+
+	// Validate CDM version is available
+	validCdmVersion := false
+	var supportedInstanceTypes []cloudcluster.GcpCCInstanceType
+	for _, version := range cdmVersions {
+		if (version.IsLatest && useLatestCdmVersion) || (version.CdmVersion == input.VMConfig.CDMVersion) {
+			validCdmVersion = true
+			input.VMConfig.CDMVersion = version.CdmVersion
+			input.VMConfig.CDMProduct = version.CdmProduct
+			supportedInstanceTypes = version.SupportedInstanceTypes
+			break
+		}
+	}
+
+	if !validCdmVersion {
+		return CloudCluster{}, fmt.Errorf("cdm version %s is not available for account %s", input.VMConfig.CDMVersion, account.ID)
+	}
+
+	// Validate dynamic scaling is only enabled for CDM version 9.5 or higher
+	if input.ClusterConfig.DynamicScalingEnabled {
+		cdmVersion, err := polcluster.ParseCDMVersion(input.VMConfig.CDMVersion)
+		if err != nil {
+			return CloudCluster{}, fmt.Errorf("failed to parse CDM version %s: %s", input.VMConfig.CDMVersion, err)
+		}
+		if cdmVersion.LessThan("9.5") {
+			return CloudCluster{}, fmt.Errorf("dynamic scaling requires CDM version 9.5 or higher, got %s", input.VMConfig.CDMVersion)
+		}
+	}
+
+	// Ensure specified instance type is supported
+	validInstanceType := slices.Contains(supportedInstanceTypes, input.VMConfig.InstanceType)
+	if !validInstanceType {
+		return CloudCluster{}, fmt.Errorf("instance type %s is not supported for cdm version %s, supported Instance types are: %v", input.VMConfig.InstanceType, input.VMConfig.CDMVersion, supportedInstanceTypes)
+	}
+
+	// Validate CloudCluster Request
+	err = cloudcluster.Wrap(a.client).ValidateCreateGcpClusterInput(ctx, input)
+	if err != nil {
+		return CloudCluster{}, fmt.Errorf("failed to validate create cloud cluster: %s", err)
+	}
+
+	// JobID is ignored here due to a bug in the RSC API
+	_, err = cloudcluster.Wrap(a.client).CreateGcpCloudCluster(ctx, input)
+	if err != nil {
+		return CloudCluster{}, fmt.Errorf("failed to create cloud cluster: %s", err)
+	}
+
+	cluster, err = a.monitorCloudClusterEvents(ctx, input.ClusterConfig.ClusterName, input.CloudAccountID, input.VMConfig.CDMVersion, input.VMConfig.CDMProduct, string(input.VMConfig.InstanceType), input.Region)
+	if err != nil {
+		return CloudCluster{}, fmt.Errorf("failed to monitor cloud cluster events: %s", err)
+	}
+
+	return cluster, nil
+}
+
+// DeleteGcpCloudCluster deletes a GCP Cloud Cluster with the specified configuration.
+func (a API) DeleteGcpCloudCluster(ctx context.Context, input cloudcluster.DeleteGcpClusterInput) (uuid.UUID, error) {
+	a.log.Print(log.Trace)
+
+	// Validate Cloud Account exists and has Server and Apps feature
+	gcpClient := polgcp.WrapGQL(a.client)
+	account, err := gcpClient.ProjectByID(ctx, input.CloudAccountID)
+	if err != nil {
+		return uuid.Nil, err
+	}
+
+	if _, ok := account.Feature(core.FeatureServerAndApps); !ok {
+		return uuid.Nil, fmt.Errorf("account %q missing feature %s", account.ID, core.FeatureServerAndApps.Name)
+	}
+
+	jobID, err := cloudcluster.Wrap(a.client).DeleteGcpCloudCluster(ctx, input)
+	if err != nil {
+		return uuid.Nil, fmt.Errorf("failed to delete cloud cluster: %s", err)
+	}
+
+	return jobID, nil
 }
 
 // monitorCloudClusterEvents monitors the events for a cloud cluster create job and returns the cloud cluster object when complete.

--- a/pkg/polaris/cloudcluster/cloudcluster.go
+++ b/pkg/polaris/cloudcluster/cloudcluster.go
@@ -373,6 +373,59 @@ func validateGcpBucketRegion(bucketRegion, clusterRegion string) error {
 	return nil
 }
 
+// gcpRegionZones returns the zones for the named region from the regions
+// returned by gcpRegions. It returns an error if the region is not available for
+// the cloud account, mirroring the RSC UI which only offers available regions.
+// The region name comparison is case-insensitive.
+func gcpRegionZones(regions []cloudcluster.GcpRegionInfo, region string) ([]string, error) {
+	for _, r := range regions {
+		if strings.EqualFold(r.Name, region) {
+			return r.Zones, nil
+		}
+	}
+	return nil, fmt.Errorf("region %q is not available for the cloud account", region)
+}
+
+// validateGcpZones checks that the cluster zone, and any Multi-AZ resiliency
+// zones, belong to the selected region, and that Multi-AZ requirements are met.
+// This mirrors the RSC UI, which only offers zones from the selected region and
+// only allows AZ resiliency when the region has at least three zones and the
+// cluster has at least three nodes. regionZones is the list of zones for
+// input.Region as returned by gcpRegions. Zone comparisons are case-insensitive.
+func validateGcpZones(input cloudcluster.CreateGcpClusterInput, regionZones []string) error {
+	inRegion := func(zone string) bool {
+		for _, z := range regionZones {
+			if strings.EqualFold(z, zone) {
+				return true
+			}
+		}
+		return false
+	}
+
+	// The cluster instance zone must belong to the selected region.
+	if input.Zone != "" && !inRegion(input.Zone) {
+		return fmt.Errorf("zone %q does not belong to region %q (region zones: %v)", input.Zone, input.Region, regionZones)
+	}
+
+	// Multi-AZ resiliency requires a region with at least three zones, at least
+	// three nodes, and each resiliency subnet's zone to belong to the region.
+	if input.IsAzResilient != nil && *input.IsAzResilient {
+		if len(regionZones) < 3 {
+			return fmt.Errorf("AZ-resilient cluster requires a region with at least 3 zones, but region %q has %d", input.Region, len(regionZones))
+		}
+		if input.ClusterConfig.NumNodes < 3 {
+			return fmt.Errorf("AZ-resilient cluster requires at least 3 nodes, got %d", input.ClusterConfig.NumNodes)
+		}
+		for _, az := range input.VMConfig.SubnetAzConfigs {
+			if !inRegion(az.AvailabilityZone) {
+				return fmt.Errorf("AZ-resiliency zone %q does not belong to region %q (region zones: %v)", az.AvailabilityZone, input.Region, regionZones)
+			}
+		}
+	}
+
+	return nil
+}
+
 // CreateGcpCloudCluster creates a GCP Cloud Cluster with the specified configuration.
 // It validates the cloud account, CDM version, and cluster input before creating the
 // cluster. Returns the created cluster details after monitoring the creation process.
@@ -434,6 +487,22 @@ func (a API) CreateGcpCloudCluster(ctx context.Context, input cloudcluster.Creat
 	// mirrors the RSC UI, which only allows selecting a bucket whose region
 	// matches the cluster region.
 	if err := validateGcpBucketRegion(input.ClusterConfig.GcpEsConfig.Region, input.Region); err != nil {
+		return CloudCluster{}, err
+	}
+
+	// Validate that the cluster zone, and any Multi-AZ resiliency zones, belong
+	// to the selected region and that Multi-AZ requirements are met. This mirrors
+	// the RSC UI, which only offers zones from the selected region and only
+	// allows AZ resiliency when the region has at least three zones.
+	regions, err := cloudcluster.Wrap(a.client).GcpRegions(ctx, input.CloudAccountID)
+	if err != nil {
+		return CloudCluster{}, fmt.Errorf("failed to get regions: %s", err)
+	}
+	regionZones, err := gcpRegionZones(regions, input.Region)
+	if err != nil {
+		return CloudCluster{}, err
+	}
+	if err := validateGcpZones(input, regionZones); err != nil {
 		return CloudCluster{}, err
 	}
 

--- a/pkg/polaris/cloudcluster/cloudcluster.go
+++ b/pkg/polaris/cloudcluster/cloudcluster.go
@@ -24,6 +24,7 @@ package cloudcluster
 import (
 	"context"
 	"encoding/json"
+	"errors"
 	"fmt"
 	"slices"
 	"strings"
@@ -373,6 +374,29 @@ func validateGcpBucketRegion(bucketRegion, clusterRegion string) error {
 	return nil
 }
 
+// isAzResilient reports whether the input requests a Multi-AZ resilient cluster.
+func isAzResilient(input cloudcluster.CreateGcpClusterInput) bool {
+	return input.IsAzResilient != nil && *input.IsAzResilient
+}
+
+// expandGcpNetworkConfig returns the network config fanned out to one entry per
+// node when a single subnet is provided for a multi-node, non-AZ-resilient
+// cluster. The backend requires len(NetworkConfig) == NumNodes and assigns
+// NetworkConfig[i] to node i; the RSC UI does the same fan-out. AZ-resilient
+// clusters are left unchanged, as their per-node subnets come from
+// SubnetAzConfigs. Any other cardinality is left to the caller and the backend.
+func expandGcpNetworkConfig(input cloudcluster.CreateGcpClusterInput) []cloudcluster.GcpSubnetInput {
+	networkConfig := input.VMConfig.NetworkConfig
+	if isAzResilient(input) || len(networkConfig) != 1 || input.ClusterConfig.NumNodes <= 1 {
+		return networkConfig
+	}
+	expanded := make([]cloudcluster.GcpSubnetInput, input.ClusterConfig.NumNodes)
+	for i := range expanded {
+		expanded[i] = networkConfig[0]
+	}
+	return expanded
+}
+
 // gcpRegionZones returns the zones for the named region from the regions
 // returned by gcpRegions. It returns an error if the region is not available for
 // the cloud account, mirroring the RSC UI which only offers available regions.
@@ -408,13 +432,17 @@ func validateGcpZones(input cloudcluster.CreateGcpClusterInput, regionZones []st
 	}
 
 	// Multi-AZ resiliency requires a region with at least three zones, at least
-	// three nodes, and each resiliency subnet's zone to belong to the region.
-	if input.IsAzResilient != nil && *input.IsAzResilient {
-		if len(regionZones) < 3 {
-			return fmt.Errorf("AZ-resilient cluster requires a region with at least 3 zones, but region %q has %d", input.Region, len(regionZones))
+	// three nodes, at least three resiliency subnets (one per zone), and each
+	// resiliency subnet's zone to belong to the region.
+	if isAzResilient(input) {
+		if len(regionZones) < minMultiAzZones {
+			return fmt.Errorf("AZ-resilient cluster requires a region with at least %d zones, but region %q has %d", minMultiAzZones, input.Region, len(regionZones))
 		}
-		if input.ClusterConfig.NumNodes < 3 {
-			return fmt.Errorf("AZ-resilient cluster requires at least 3 nodes, got %d", input.ClusterConfig.NumNodes)
+		if input.ClusterConfig.NumNodes < minMultiAzZones {
+			return fmt.Errorf("AZ-resilient cluster requires at least %d nodes, got %d", minMultiAzZones, input.ClusterConfig.NumNodes)
+		}
+		if len(input.VMConfig.SubnetAzConfigs) < minMultiAzZones {
+			return fmt.Errorf("AZ-resilient cluster requires at least %d resiliency subnets (one per zone), got %d", minMultiAzZones, len(input.VMConfig.SubnetAzConfigs))
 		}
 		for _, az := range input.VMConfig.SubnetAzConfigs {
 			if !inRegion(az.AvailabilityZone) {
@@ -426,11 +454,34 @@ func validateGcpZones(input cloudcluster.CreateGcpClusterInput, regionZones []st
 	return nil
 }
 
-// CreateGcpCloudCluster creates a GCP Cloud Cluster with the specified configuration.
-// It validates the cloud account, CDM version, and cluster input before creating the
-// cluster. Returns the created cluster details after monitoring the creation process.
+// minCDMVersionGcpDynamicScaling is the minimum CDM version that supports
+// dynamic scaling. It matches the RSC UI's MIN_CDM_VERSION_DYNAMIC_SCALING_ENABLED
+// constant.
+const minCDMVersionGcpDynamicScaling = "9.4.3"
+
+// minMultiAzZones is the minimum number of zones, nodes, and resiliency subnets
+// required for an AZ-resilient GCP cluster. It matches the backend's
+// MinMultiAzAvailabilityZones constant.
+const minMultiAzZones = 3
+
+// CreateGcpCloudCluster creates an Elastic Storage (ES) GCP Cloud Cluster with
+// the specified configuration. It validates the cloud account, CDM version, and
+// cluster input before creating the cluster, then monitors the creation process.
+//
+// The following fields are defaulted to match the RSC UI and are not required on
+// the input: IsEsType is forced to true (this method only provisions ES
+// clusters) and Validations defaults to ALL_CHECKS when empty. DeleteProtection
+// is left to the caller; the RSC UI defaults it to true.
 func (a API) CreateGcpCloudCluster(ctx context.Context, input cloudcluster.CreateGcpClusterInput, useLatestCdmVersion bool) (cluster CloudCluster, err error) {
 	a.log.Print(log.Trace)
+
+	// This method provisions ES clusters and depends on the Server and Apps
+	// feature, so force the ES type and default the validations to ALL_CHECKS,
+	// matching the RSC UI.
+	input.IsEsType = true
+	if len(input.Validations) == 0 {
+		input.Validations = []cloudcluster.ClusterCreateValidations{cloudcluster.AllChecks}
+	}
 
 	// Validate Cloud Account exists and has Server and Apps feature
 	gcpClient := polgcp.WrapGQL(a.client)
@@ -466,14 +517,14 @@ func (a API) CreateGcpCloudCluster(ctx context.Context, input cloudcluster.Creat
 		return CloudCluster{}, fmt.Errorf("cdm version %s is not available for account %s", input.VMConfig.CDMVersion, account.ID)
 	}
 
-	// Validate dynamic scaling is only enabled for CDM version 9.5 or higher
+	// Validate dynamic scaling is only enabled for a supported CDM version.
 	if input.ClusterConfig.DynamicScalingEnabled {
 		cdmVersion, err := polcluster.ParseCDMVersion(input.VMConfig.CDMVersion)
 		if err != nil {
 			return CloudCluster{}, fmt.Errorf("failed to parse CDM version %s: %s", input.VMConfig.CDMVersion, err)
 		}
-		if cdmVersion.LessThan("9.5") {
-			return CloudCluster{}, fmt.Errorf("dynamic scaling requires CDM version 9.5 or higher, got %s", input.VMConfig.CDMVersion)
+		if cdmVersion.LessThan(minCDMVersionGcpDynamicScaling) {
+			return CloudCluster{}, fmt.Errorf("dynamic scaling requires CDM version %s or higher, got %s", minCDMVersionGcpDynamicScaling, input.VMConfig.CDMVersion)
 		}
 	}
 
@@ -481,6 +532,19 @@ func (a API) CreateGcpCloudCluster(ctx context.Context, input cloudcluster.Creat
 	validInstanceType := slices.Contains(supportedInstanceTypes, input.VMConfig.InstanceType)
 	if !validInstanceType {
 		return CloudCluster{}, fmt.Errorf("instance type %s is not supported for cdm version %s, supported Instance types are: %v", input.VMConfig.InstanceType, input.VMConfig.CDMVersion, supportedInstanceTypes)
+	}
+
+	// The backend requires one network config entry per node and assigns
+	// NetworkConfig[i] to node i. Mirror the RSC UI by fanning out a single
+	// provided subnet across all nodes.
+	input.VMConfig.NetworkConfig = expandGcpNetworkConfig(input)
+
+	// The RSC UI requires at least one network subnet and one service account.
+	if len(input.VMConfig.NetworkConfig) == 0 {
+		return CloudCluster{}, errors.New("at least one network subnet is required")
+	}
+	if len(input.VMConfig.ServiceAccounts) == 0 {
+		return CloudCluster{}, errors.New("at least one service account is required")
 	}
 
 	// Validate that the GCS bucket is in the same region as the cluster. This

--- a/pkg/polaris/cloudcluster/cloudcluster.go
+++ b/pkg/polaris/cloudcluster/cloudcluster.go
@@ -26,6 +26,7 @@ import (
 	"encoding/json"
 	"fmt"
 	"slices"
+	"strings"
 	"time"
 
 	"github.com/google/uuid"
@@ -358,6 +359,20 @@ func (a API) CreateAzureCloudCluster(ctx context.Context, input cloudcluster.Cre
 	return cluster, nil
 }
 
+// validateGcpBucketRegion returns an error if the GCS bucket region does not
+// match the cluster region. RSC requires the cluster's object store to be in the
+// same region as the cluster; the RSC UI enforces this by only listing buckets
+// whose region matches the selected cluster region. The comparison is
+// case-insensitive since the GCS bucket location (e.g. US-EAST1) and the cluster
+// region (e.g. us-east1) differ in case. An empty bucket region is allowed, e.g.
+// when creating a new bucket, and is left to the backend to default.
+func validateGcpBucketRegion(bucketRegion, clusterRegion string) error {
+	if bucketRegion != "" && !strings.EqualFold(bucketRegion, clusterRegion) {
+		return fmt.Errorf("GCS bucket region %q does not match cluster region %q: the bucket must be in the same region as the cluster", bucketRegion, clusterRegion)
+	}
+	return nil
+}
+
 // CreateGcpCloudCluster creates a GCP Cloud Cluster with the specified configuration.
 // It validates the cloud account, CDM version, and cluster input before creating the
 // cluster. Returns the created cluster details after monitoring the creation process.
@@ -413,6 +428,13 @@ func (a API) CreateGcpCloudCluster(ctx context.Context, input cloudcluster.Creat
 	validInstanceType := slices.Contains(supportedInstanceTypes, input.VMConfig.InstanceType)
 	if !validInstanceType {
 		return CloudCluster{}, fmt.Errorf("instance type %s is not supported for cdm version %s, supported Instance types are: %v", input.VMConfig.InstanceType, input.VMConfig.CDMVersion, supportedInstanceTypes)
+	}
+
+	// Validate that the GCS bucket is in the same region as the cluster. This
+	// mirrors the RSC UI, which only allows selecting a bucket whose region
+	// matches the cluster region.
+	if err := validateGcpBucketRegion(input.ClusterConfig.GcpEsConfig.Region, input.Region); err != nil {
+		return CloudCluster{}, err
 	}
 
 	// Validate CloudCluster Request

--- a/pkg/polaris/cloudcluster/cloudcluster_gcp_test.go
+++ b/pkg/polaris/cloudcluster/cloudcluster_gcp_test.go
@@ -20,7 +20,13 @@
 
 package cloudcluster
 
-import "testing"
+import (
+	"testing"
+
+	"github.com/rubrikinc/rubrik-polaris-sdk-for-go/pkg/polaris/graphql/cloudcluster"
+)
+
+func boolPtr(b bool) *bool { return &b }
 
 func TestValidateGcpBucketRegion(t *testing.T) {
 	tests := []struct {
@@ -64,6 +70,148 @@ func TestValidateGcpBucketRegion(t *testing.T) {
 	for _, tt := range tests {
 		t.Run(tt.name, func(t *testing.T) {
 			err := validateGcpBucketRegion(tt.bucketRegion, tt.clusterRegion)
+			if tt.expectErr && err == nil {
+				t.Errorf("expected error but got none")
+			}
+			if !tt.expectErr && err != nil {
+				t.Errorf("unexpected error: %v", err)
+			}
+		})
+	}
+}
+
+func TestGcpRegionZones(t *testing.T) {
+	regions := []cloudcluster.GcpRegionInfo{
+		{Name: "us-west1", Zones: []string{"us-west1-a", "us-west1-b", "us-west1-c"}},
+		{Name: "us-east4", Zones: []string{"us-east4-a", "us-east4-b"}},
+	}
+
+	t.Run("FoundCaseInsensitive", func(t *testing.T) {
+		zones, err := gcpRegionZones(regions, "US-WEST1")
+		if err != nil {
+			t.Fatalf("unexpected error: %v", err)
+		}
+		if len(zones) != 3 {
+			t.Errorf("expected 3 zones, got %d", len(zones))
+		}
+	})
+
+	t.Run("NotAvailable", func(t *testing.T) {
+		if _, err := gcpRegionZones(regions, "europe-west1"); err == nil {
+			t.Error("expected error for unavailable region but got none")
+		}
+	})
+}
+
+func TestValidateGcpZones(t *testing.T) {
+	threeZones := []string{"us-west1-a", "us-west1-b", "us-west1-c"}
+	twoZones := []string{"us-east4-a", "us-east4-b"}
+
+	tests := []struct {
+		name        string
+		input       cloudcluster.CreateGcpClusterInput
+		regionZones []string
+		expectErr   bool
+	}{
+		{
+			name: "ZoneInRegion",
+			input: cloudcluster.CreateGcpClusterInput{
+				Region: "us-west1",
+				Zone:   "us-west1-a",
+			},
+			regionZones: threeZones,
+			expectErr:   false,
+		},
+		{
+			name: "ZoneInRegionCaseInsensitive",
+			input: cloudcluster.CreateGcpClusterInput{
+				Region: "us-west1",
+				Zone:   "US-WEST1-A",
+			},
+			regionZones: threeZones,
+			expectErr:   false,
+		},
+		{
+			name: "ZoneNotInRegion",
+			input: cloudcluster.CreateGcpClusterInput{
+				Region: "us-west1",
+				Zone:   "us-east4-a",
+			},
+			regionZones: threeZones,
+			expectErr:   true,
+		},
+		{
+			name: "AzResilientValid",
+			input: cloudcluster.CreateGcpClusterInput{
+				Region:        "us-west1",
+				Zone:          "us-west1-a",
+				IsAzResilient: boolPtr(true),
+				ClusterConfig: cloudcluster.GcpClusterConfig{NumNodes: 3},
+				VMConfig: cloudcluster.GcpVmConfig{
+					SubnetAzConfigs: []cloudcluster.SubnetAzConfig{
+						{AvailabilityZone: "us-west1-a", Subnet: "subnet-a"},
+						{AvailabilityZone: "us-west1-b", Subnet: "subnet-b"},
+						{AvailabilityZone: "us-west1-c", Subnet: "subnet-c"},
+					},
+				},
+			},
+			regionZones: threeZones,
+			expectErr:   false,
+		},
+		{
+			name: "AzResilientTooFewRegionZones",
+			input: cloudcluster.CreateGcpClusterInput{
+				Region:        "us-east4",
+				Zone:          "us-east4-a",
+				IsAzResilient: boolPtr(true),
+				ClusterConfig: cloudcluster.GcpClusterConfig{NumNodes: 3},
+			},
+			regionZones: twoZones,
+			expectErr:   true,
+		},
+		{
+			name: "AzResilientTooFewNodes",
+			input: cloudcluster.CreateGcpClusterInput{
+				Region:        "us-west1",
+				Zone:          "us-west1-a",
+				IsAzResilient: boolPtr(true),
+				ClusterConfig: cloudcluster.GcpClusterConfig{NumNodes: 1},
+			},
+			regionZones: threeZones,
+			expectErr:   true,
+		},
+		{
+			name: "AzResilientSubnetZoneNotInRegion",
+			input: cloudcluster.CreateGcpClusterInput{
+				Region:        "us-west1",
+				Zone:          "us-west1-a",
+				IsAzResilient: boolPtr(true),
+				ClusterConfig: cloudcluster.GcpClusterConfig{NumNodes: 3},
+				VMConfig: cloudcluster.GcpVmConfig{
+					SubnetAzConfigs: []cloudcluster.SubnetAzConfig{
+						{AvailabilityZone: "us-east4-a", Subnet: "subnet-a"},
+					},
+				},
+			},
+			regionZones: threeZones,
+			expectErr:   true,
+		},
+		{
+			name: "NonResilientIgnoresNodeAndZoneCount",
+			input: cloudcluster.CreateGcpClusterInput{
+				Region:        "us-east4",
+				Zone:          "us-east4-a",
+				IsAzResilient: boolPtr(false),
+				ClusterConfig: cloudcluster.GcpClusterConfig{NumNodes: 1},
+			},
+			regionZones: twoZones,
+			expectErr:   false,
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			err := validateGcpZones(tt.input, tt.regionZones)
 			if tt.expectErr && err == nil {
 				t.Errorf("expected error but got none")
 			}

--- a/pkg/polaris/cloudcluster/cloudcluster_gcp_test.go
+++ b/pkg/polaris/cloudcluster/cloudcluster_gcp_test.go
@@ -1,0 +1,75 @@
+// Copyright 2026 Rubrik, Inc.
+//
+// Permission is hereby granted, free of charge, to any person obtaining a copy
+// of this software and associated documentation files (the "Software"), to
+// deal in the Software without restriction, including without limitation the
+// rights to use, copy, modify, merge, publish, distribute, sublicense, and/or
+// sell copies of the Software, and to permit persons to whom the Software is
+// furnished to do so, subject to the following conditions:
+//
+// The above copyright notice and this permission notice shall be included in
+// all copies or substantial portions of the Software.
+//
+// THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+// IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+// FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+// AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+// LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING
+// FROM, OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER
+// DEALINGS IN THE SOFTWARE.
+
+package cloudcluster
+
+import "testing"
+
+func TestValidateGcpBucketRegion(t *testing.T) {
+	tests := []struct {
+		name          string
+		bucketRegion  string
+		clusterRegion string
+		expectErr     bool
+	}{
+		{
+			name:          "ExactMatch",
+			bucketRegion:  "us-east1",
+			clusterRegion: "us-east1",
+			expectErr:     false,
+		},
+		{
+			name:          "CaseInsensitiveMatch",
+			bucketRegion:  "US-EAST1",
+			clusterRegion: "us-east1",
+			expectErr:     false,
+		},
+		{
+			name:          "RegionMismatch",
+			bucketRegion:  "us-central1",
+			clusterRegion: "us-east1",
+			expectErr:     true,
+		},
+		{
+			name:          "MultiRegionDoesNotMatchRegional",
+			bucketRegion:  "US",
+			clusterRegion: "us-east1",
+			expectErr:     true,
+		},
+		{
+			name:          "EmptyBucketRegionAllowed",
+			bucketRegion:  "",
+			clusterRegion: "us-east1",
+			expectErr:     false,
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			err := validateGcpBucketRegion(tt.bucketRegion, tt.clusterRegion)
+			if tt.expectErr && err == nil {
+				t.Errorf("expected error but got none")
+			}
+			if !tt.expectErr && err != nil {
+				t.Errorf("unexpected error: %v", err)
+			}
+		})
+	}
+}

--- a/pkg/polaris/cloudcluster/cloudcluster_gcp_test.go
+++ b/pkg/polaris/cloudcluster/cloudcluster_gcp_test.go
@@ -103,6 +103,52 @@ func TestGcpRegionZones(t *testing.T) {
 	})
 }
 
+func TestExpandGcpNetworkConfig(t *testing.T) {
+	subnet := cloudcluster.GcpSubnetInput{Name: "subnet-a", Network: "vpc", HostProject: "p", Region: "us-west1"}
+
+	mk := func(numNodes int, azResilient bool, nc []cloudcluster.GcpSubnetInput) cloudcluster.CreateGcpClusterInput {
+		in := cloudcluster.CreateGcpClusterInput{
+			ClusterConfig: cloudcluster.GcpClusterConfig{NumNodes: numNodes},
+			VMConfig:      cloudcluster.GcpVmConfig{NetworkConfig: nc},
+		}
+		if azResilient {
+			in.IsAzResilient = boolPtr(true)
+		}
+		return in
+	}
+
+	t.Run("SingleSubnetMultiNodeFansOut", func(t *testing.T) {
+		got := expandGcpNetworkConfig(mk(3, false, []cloudcluster.GcpSubnetInput{subnet}))
+		if len(got) != 3 {
+			t.Fatalf("expected 3 entries, got %d", len(got))
+		}
+		for i, s := range got {
+			if s != subnet {
+				t.Errorf("entry %d = %+v, want %+v", i, s, subnet)
+			}
+		}
+	})
+
+	t.Run("SingleNodeUnchanged", func(t *testing.T) {
+		if got := expandGcpNetworkConfig(mk(1, false, []cloudcluster.GcpSubnetInput{subnet})); len(got) != 1 {
+			t.Errorf("expected 1 entry, got %d", len(got))
+		}
+	})
+
+	t.Run("AlreadyPerNodeUnchanged", func(t *testing.T) {
+		nc := []cloudcluster.GcpSubnetInput{subnet, subnet, subnet}
+		if got := expandGcpNetworkConfig(mk(3, false, nc)); len(got) != 3 {
+			t.Errorf("expected 3 entries, got %d", len(got))
+		}
+	})
+
+	t.Run("AzResilientUnchanged", func(t *testing.T) {
+		if got := expandGcpNetworkConfig(mk(3, true, []cloudcluster.GcpSubnetInput{subnet})); len(got) != 1 {
+			t.Errorf("expected AZ-resilient to be left unchanged at 1 entry, got %d", len(got))
+		}
+	})
+}
+
 func TestValidateGcpZones(t *testing.T) {
 	threeZones := []string{"us-west1-a", "us-west1-b", "us-west1-c"}
 	twoZones := []string{"us-east4-a", "us-east4-b"}
@@ -181,6 +227,23 @@ func TestValidateGcpZones(t *testing.T) {
 			expectErr:   true,
 		},
 		{
+			name: "AzResilientTooFewSubnets",
+			input: cloudcluster.CreateGcpClusterInput{
+				Region:        "us-west1",
+				Zone:          "us-west1-a",
+				IsAzResilient: boolPtr(true),
+				ClusterConfig: cloudcluster.GcpClusterConfig{NumNodes: 3},
+				VMConfig: cloudcluster.GcpVmConfig{
+					SubnetAzConfigs: []cloudcluster.SubnetAzConfig{
+						{AvailabilityZone: "us-west1-a", Subnet: "subnet-a"},
+						{AvailabilityZone: "us-west1-b", Subnet: "subnet-b"},
+					},
+				},
+			},
+			regionZones: threeZones,
+			expectErr:   true,
+		},
+		{
 			name: "AzResilientSubnetZoneNotInRegion",
 			input: cloudcluster.CreateGcpClusterInput{
 				Region:        "us-west1",
@@ -189,7 +252,9 @@ func TestValidateGcpZones(t *testing.T) {
 				ClusterConfig: cloudcluster.GcpClusterConfig{NumNodes: 3},
 				VMConfig: cloudcluster.GcpVmConfig{
 					SubnetAzConfigs: []cloudcluster.SubnetAzConfig{
-						{AvailabilityZone: "us-east4-a", Subnet: "subnet-a"},
+						{AvailabilityZone: "us-west1-a", Subnet: "subnet-a"},
+						{AvailabilityZone: "us-west1-b", Subnet: "subnet-b"},
+						{AvailabilityZone: "us-east4-a", Subnet: "subnet-c"},
 					},
 				},
 			},

--- a/pkg/polaris/graphql/cloudcluster/cloudcluster.go
+++ b/pkg/polaris/graphql/cloudcluster/cloudcluster.go
@@ -115,7 +115,13 @@ type AzureEsConfigInput struct {
 
 // GcpEsConfigInput represents the input for creating a GCP ES config.
 type GcpEsConfigInput struct {
-	BucketName         string `json:"bucketName"`
+	BucketName string `json:"bucketName"`
+	// Region should be the GCS bucket's actual location. RSC requires the bucket
+	// to be in the same region as the cluster, and the high-level
+	// CreateGcpCloudCluster validates this against the cluster region. Note the
+	// RSC UI instead sets this to the cluster region and filters buckets by
+	// location client-side, so when following UI semantics this is always the
+	// cluster region.
 	Region             string `json:"region"`
 	ShouldCreateBucket bool   `json:"shouldCreateBucket"`
 }

--- a/pkg/polaris/graphql/cloudcluster/cloudcluster_gcp.go
+++ b/pkg/polaris/graphql/cloudcluster/cloudcluster_gcp.go
@@ -1,0 +1,395 @@
+// Copyright 2026 Rubrik, Inc.
+//
+// Permission is hereby granted, free of charge, to any person obtaining a copy
+// of this software and associated documentation files (the "Software"), to
+// deal in the Software without restriction, including without limitation the
+// rights to use, copy, modify, merge, publish, distribute, sublicense, and/or
+// sell copies of the Software, and to permit persons to whom the Software is
+// furnished to do so, subject to the following conditions:
+//
+// The above copyright notice and this permission notice shall be included in
+// all copies or substantial portions of the Software.
+//
+// THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+// IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+// FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+// AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+// LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING
+// FROM, OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER
+// DEALINGS IN THE SOFTWARE.
+
+package cloudcluster
+
+import (
+	"context"
+	"encoding/json"
+	"errors"
+
+	"github.com/google/uuid"
+
+	"github.com/rubrikinc/rubrik-polaris-sdk-for-go/pkg/polaris/graphql"
+	"github.com/rubrikinc/rubrik-polaris-sdk-for-go/pkg/polaris/graphql/core/secret"
+)
+
+// GcpCCInstanceType represents the instance types for GCP Cloud Cluster.
+type GcpCCInstanceType string
+
+const (
+	GcpInstanceTypeUnspecified   GcpCCInstanceType = "GCP_TYPE_UNSPECIFIED"
+	GcpInstanceTypeN2Standard8   GcpCCInstanceType = "N2_STANDARD_8"
+	GcpInstanceTypeN2Standard16  GcpCCInstanceType = "N2_STANDARD_16"
+	GcpInstanceTypeN2Highmem16   GcpCCInstanceType = "N2_HIGHMEM_16"
+	GcpInstanceTypeN2DStandard8  GcpCCInstanceType = "N2D_STANDARD_8"
+	GcpInstanceTypeN2DStandard16 GcpCCInstanceType = "N2D_STANDARD_16"
+	GcpInstanceTypeN2DHighmem16  GcpCCInstanceType = "N2D_HIGHMEM_16"
+)
+
+// GcpCdmVersion represents the CDM version for GCP Cloud Cluster.
+type GcpCdmVersion struct {
+	CdmVersion             string              `json:"cdmVersion"`
+	CdmProduct             string              `json:"cdmProduct"`
+	ImageID                string              `json:"imageId"`
+	IsLatest               bool                `json:"isLatest"`
+	SupportedInstanceTypes []GcpCCInstanceType `json:"supportedInstanceTypes"`
+}
+
+// GcpRegionInfo represents a GCP region with its availability zones.
+type GcpRegionInfo struct {
+	Name  string   `json:"name"`
+	Zones []string `json:"zones"`
+}
+
+// GcpSubnet represents a GCP subnet.
+type GcpSubnet struct {
+	HostProject string `json:"hostProject"`
+	Name        string `json:"name"`
+	Network     string `json:"network"`
+	Region      string `json:"region"`
+}
+
+// GcpServiceAccount represents a GCP service account.
+type GcpServiceAccount struct {
+	Email  string   `json:"email"`
+	Name   string   `json:"name"`
+	Scopes []string `json:"scopes"`
+}
+
+// GcpBucket represents a GCP storage bucket.
+type GcpBucket struct {
+	BucketName         string `json:"bucketName"`
+	Region             string `json:"region"`
+	ShouldCreateBucket bool   `json:"shouldCreateBucket"`
+}
+
+// GcpSubnetInput represents the subnet input for GCP Cloud Cluster VM config.
+type GcpSubnetInput struct {
+	HostProject string `json:"hostProject,omitempty"`
+	Name        string `json:"name,omitempty"`
+	Network     string `json:"network,omitempty"`
+	Region      string `json:"region,omitempty"`
+}
+
+// GcpServiceAccountInput represents the service account input for GCP Cloud Cluster VM config.
+type GcpServiceAccountInput struct {
+	Email  string   `json:"email,omitempty"`
+	Name   string   `json:"name,omitempty"`
+	Scopes []string `json:"scopes,omitempty"`
+}
+
+// SubnetAzConfig represents the subnet availability zone configuration for GCP Cloud Cluster.
+type SubnetAzConfig struct {
+	AvailabilityZone string `json:"availabilityZone,omitempty"`
+	Subnet           string `json:"subnet,omitempty"`
+}
+
+// GcpVmConfig represents the VM configuration for the GCP Cloud Cluster.
+type GcpVmConfig struct {
+	CDMProduct       string                   `json:"cdmProduct,omitempty"`
+	CDMVersion       string                   `json:"cdmVersion,omitempty"`
+	DeleteProtection bool                     `json:"deleteProtection"`
+	InstanceType     GcpCCInstanceType        `json:"instanceType"`
+	NetworkConfig    []GcpSubnetInput         `json:"networkConfig"`
+	ServiceAccounts  []GcpServiceAccountInput `json:"serviceAccounts"`
+	SubnetAzConfigs  []SubnetAzConfig         `json:"subnetAzConfigs,omitempty"`
+	VMType           VmConfigType             `json:"vmType"`
+}
+
+// GcpClusterConfig represents the cluster configuration for the GCP Cloud Cluster.
+type GcpClusterConfig struct {
+	ClusterName           string           `json:"clusterName"`
+	UserEmail             string           `json:"userEmail"`
+	AdminPassword         secret.String    `json:"adminPassword"`
+	DNSNameServers        []string         `json:"dnsNameServers"`
+	DNSSearchDomains      []string         `json:"dnsSearchDomains"`
+	NTPServers            []string         `json:"ntpServers"`
+	NumNodes              int              `json:"numNodes"`
+	GcpEsConfig           GcpEsConfigInput `json:"gcpEsConfig"`
+	DynamicScalingEnabled bool             `json:"dynamicScalingEnabled,omitempty"`
+}
+
+// CreateGcpClusterInput represents the input for creating a GCP Cloud Cluster.
+type CreateGcpClusterInput struct {
+	CloudAccountID       uuid.UUID                  `json:"cloudAccountId"`
+	ClusterConfig        GcpClusterConfig           `json:"clusterConfig"`
+	IsAzResilient        *bool                      `json:"isAzResilient,omitempty"`
+	IsEsType             bool                       `json:"isEsType"`
+	KeepClusterOnFailure bool                       `json:"keepClusterOnFailure"`
+	Region               string                     `json:"region"`
+	Validations          []ClusterCreateValidations `json:"validations"`
+	VMConfig             GcpVmConfig                `json:"vmConfig"`
+	Zone                 string                     `json:"zone"`
+}
+
+// DeleteGcpClusterInput represents the input for deleting a GCP Cloud Cluster.
+type DeleteGcpClusterInput struct {
+	CloudAccountID uuid.UUID `json:"cloudAccountId"`
+	ClusterUUID    uuid.UUID `json:"clusterUuid"`
+	IsEsType       bool      `json:"isEsType"`
+	NumNodes       int       `json:"numNodes,omitempty"`
+}
+
+// AllGcpCdmVersions returns all the available CDM versions for the specified
+// GCP cloud account.
+func (a API) AllGcpCdmVersions(ctx context.Context, cloudAccountID uuid.UUID) ([]GcpCdmVersion, error) {
+	query := gcpCcCdmVersionsQuery
+	buf, err := a.GQL.Request(ctx, query, struct {
+		Input struct {
+			CloudAccountID string `json:"cloudAccountId"`
+		} `json:"input"`
+	}{Input: struct {
+		CloudAccountID string `json:"cloudAccountId"`
+	}{CloudAccountID: cloudAccountID.String()}})
+	if err != nil {
+		return nil, graphql.RequestError(query, err)
+	}
+
+	var payload struct {
+		Data struct {
+			Result struct {
+				CdmVersions []GcpCdmVersion `json:"cdmVersions"`
+			} `json:"result"`
+		} `json:"data"`
+	}
+	if err := json.Unmarshal(buf, &payload); err != nil {
+		return nil, graphql.UnmarshalError(query, err)
+	}
+
+	return payload.Data.Result.CdmVersions, nil
+}
+
+// GcpRegions returns all the available regions for the specified GCP cloud account.
+func (a API) GcpRegions(ctx context.Context, cloudAccountID uuid.UUID) ([]GcpRegionInfo, error) {
+	query := gcpCcRegionsQuery
+	buf, err := a.GQL.Request(ctx, query, struct {
+		Input struct {
+			CloudAccountID string `json:"cloudAccountId"`
+		} `json:"input"`
+	}{Input: struct {
+		CloudAccountID string `json:"cloudAccountId"`
+	}{CloudAccountID: cloudAccountID.String()}})
+	if err != nil {
+		return nil, graphql.RequestError(query, err)
+	}
+
+	var payload struct {
+		Data struct {
+			Result struct {
+				GcpRegions []GcpRegionInfo `json:"gcpRegions"`
+			} `json:"result"`
+		} `json:"data"`
+	}
+	if err := json.Unmarshal(buf, &payload); err != nil {
+		return nil, graphql.UnmarshalError(query, err)
+	}
+
+	return payload.Data.Result.GcpRegions, nil
+}
+
+// GcpSubnets returns all the available subnets for the specified GCP cloud account and region.
+func (a API) GcpSubnets(ctx context.Context, cloudAccountID uuid.UUID, region string) ([]GcpSubnet, error) {
+	query := gcpCcSubnetsQuery
+	buf, err := a.GQL.Request(ctx, query, struct {
+		Input struct {
+			CloudAccountID string `json:"cloudAccountId"`
+			Region         string `json:"region"`
+		} `json:"input"`
+	}{Input: struct {
+		CloudAccountID string `json:"cloudAccountId"`
+		Region         string `json:"region"`
+	}{CloudAccountID: cloudAccountID.String(), Region: region}})
+	if err != nil {
+		return nil, graphql.RequestError(query, err)
+	}
+
+	var payload struct {
+		Data struct {
+			Result struct {
+				Subnets []GcpSubnet `json:"subnets"`
+			} `json:"result"`
+		} `json:"data"`
+	}
+	if err := json.Unmarshal(buf, &payload); err != nil {
+		return nil, graphql.UnmarshalError(query, err)
+	}
+
+	return payload.Data.Result.Subnets, nil
+}
+
+// GcpServiceAccounts returns all the available service accounts for the specified GCP cloud account.
+func (a API) GcpServiceAccounts(ctx context.Context, cloudAccountID uuid.UUID) ([]GcpServiceAccount, error) {
+	query := gcpCcServiceAccountsQuery
+	buf, err := a.GQL.Request(ctx, query, struct {
+		Input struct {
+			CloudAccountID string `json:"cloudAccountId"`
+		} `json:"input"`
+	}{Input: struct {
+		CloudAccountID string `json:"cloudAccountId"`
+	}{CloudAccountID: cloudAccountID.String()}})
+	if err != nil {
+		return nil, graphql.RequestError(query, err)
+	}
+
+	var payload struct {
+		Data struct {
+			Result struct {
+				ServiceAccounts []GcpServiceAccount `json:"serviceAccounts"`
+			} `json:"result"`
+		} `json:"data"`
+	}
+	if err := json.Unmarshal(buf, &payload); err != nil {
+		return nil, graphql.UnmarshalError(query, err)
+	}
+
+	return payload.Data.Result.ServiceAccounts, nil
+}
+
+// GcpBuckets returns all the available buckets for the specified GCP cloud account.
+func (a API) GcpBuckets(ctx context.Context, cloudAccountID uuid.UUID) ([]GcpBucket, error) {
+	query := gcpCcBucketsQuery
+	buf, err := a.GQL.Request(ctx, query, struct {
+		Input struct {
+			CloudAccountID string `json:"cloudAccountId"`
+		} `json:"input"`
+	}{Input: struct {
+		CloudAccountID string `json:"cloudAccountId"`
+	}{CloudAccountID: cloudAccountID.String()}})
+	if err != nil {
+		return nil, graphql.RequestError(query, err)
+	}
+
+	var payload struct {
+		Data struct {
+			Result struct {
+				Buckets []GcpBucket `json:"buckets"`
+			} `json:"result"`
+		} `json:"data"`
+	}
+	if err := json.Unmarshal(buf, &payload); err != nil {
+		return nil, graphql.UnmarshalError(query, err)
+	}
+
+	return payload.Data.Result.Buckets, nil
+}
+
+// ValidateCreateGcpClusterInput validates the GCP cloud cluster create request.
+func (a API) ValidateCreateGcpClusterInput(ctx context.Context, input CreateGcpClusterInput) error {
+	query := validateGcpClusterCreateRequestQuery
+	buf, err := a.GQL.Request(ctx, query, struct {
+		Input CreateGcpClusterInput `json:"input"`
+	}{Input: input})
+	if err != nil {
+		return graphql.RequestError(query, err)
+	}
+
+	var payload struct {
+		Data struct {
+			Result struct {
+				IsSuccessful bool   `json:"isSuccessful"`
+				Message      string `json:"message"`
+			} `json:"result"`
+		} `json:"data"`
+	}
+	if err := json.Unmarshal(buf, &payload); err != nil {
+		return graphql.UnmarshalError(query, err)
+	}
+
+	if !payload.Data.Result.IsSuccessful {
+		return graphql.ResponseError(query, errors.New(payload.Data.Result.Message))
+	}
+
+	return nil
+}
+
+// CreateGcpCloudCluster creates a GCP Cloud Cluster in RSC.
+func (a API) CreateGcpCloudCluster(ctx context.Context, input CreateGcpClusterInput) (uuid.UUID, error) {
+	query := createGcpCloudClusterQuery
+	buf, err := a.GQL.Request(ctx, query, struct {
+		Input CreateGcpClusterInput `json:"input"`
+	}{Input: input})
+	if err != nil {
+		return uuid.Nil, graphql.RequestError(query, err)
+	}
+
+	var payload struct {
+		Data struct {
+			Result struct {
+				JobID   int    `json:"jobId"`
+				Message string `json:"message"`
+				Success bool   `json:"success"`
+			} `json:"result"`
+		} `json:"data"`
+	}
+	if err := json.Unmarshal(buf, &payload); err != nil {
+		return uuid.Nil, graphql.UnmarshalError(query, err)
+	}
+
+	if !payload.Data.Result.Success {
+		return uuid.Nil, graphql.ResponseError(query, errors.New(payload.Data.Result.Message))
+	}
+
+	// Use regex to find the UUID in the message string.
+	match := uuidRegex.FindString(payload.Data.Result.Message)
+	jobID, err := uuid.Parse(match)
+	if err != nil {
+		return uuid.Nil, err
+	}
+
+	return jobID, nil
+}
+
+// DeleteGcpCloudCluster deletes a GCP Cloud Cluster in RSC.
+func (a API) DeleteGcpCloudCluster(ctx context.Context, input DeleteGcpClusterInput) (uuid.UUID, error) {
+	query := deleteGcpCcClusterQuery
+	buf, err := a.GQL.Request(ctx, query, struct {
+		Input DeleteGcpClusterInput `json:"input"`
+	}{Input: input})
+	if err != nil {
+		return uuid.Nil, graphql.RequestError(query, err)
+	}
+
+	var payload struct {
+		Data struct {
+			Result struct {
+				JobID   int    `json:"jobId"`
+				Message string `json:"message"`
+				Success bool   `json:"success"`
+			} `json:"result"`
+		} `json:"data"`
+	}
+	if err := json.Unmarshal(buf, &payload); err != nil {
+		return uuid.Nil, graphql.UnmarshalError(query, err)
+	}
+
+	if !payload.Data.Result.Success {
+		return uuid.Nil, graphql.ResponseError(query, errors.New(payload.Data.Result.Message))
+	}
+
+	// Use regex to find the UUID in the message string.
+	match := uuidRegex.FindString(payload.Data.Result.Message)
+	jobID, err := uuid.Parse(match)
+	if err != nil {
+		return uuid.Nil, err
+	}
+
+	return jobID, nil
+}

--- a/pkg/polaris/graphql/cloudcluster/cloudcluster_gcp.go
+++ b/pkg/polaris/graphql/cloudcluster/cloudcluster_gcp.go
@@ -105,18 +105,25 @@ type GcpTestImage struct {
 
 // GcpVmConfig represents the VM configuration for the GCP Cloud Cluster.
 type GcpVmConfig struct {
-	CDMProduct       string                   `json:"cdmProduct,omitempty"`
-	CDMVersion       string                   `json:"cdmVersion,omitempty"`
-	DeleteProtection bool                     `json:"deleteProtection"`
-	ImageID          string                   `json:"imageId,omitempty"`
-	InstanceType     GcpCCInstanceType        `json:"instanceType"`
-	Labels           string                   `json:"labels,omitempty"`
-	NetworkConfig    []GcpSubnetInput         `json:"networkConfig"`
-	NodeSizeGB       int                      `json:"nodeSizeGb,omitempty"`
-	ServiceAccounts  []GcpServiceAccountInput `json:"serviceAccounts"`
-	SubnetAzConfigs  []SubnetAzConfig         `json:"subnetAzConfigs,omitempty"`
-	TestImage        *GcpTestImage            `json:"testImage,omitempty"`
-	VMType           VmConfigType             `json:"vmType"`
+	CDMProduct       string            `json:"cdmProduct,omitempty"`
+	CDMVersion       string            `json:"cdmVersion,omitempty"`
+	DeleteProtection bool              `json:"deleteProtection"`
+	ImageID          string            `json:"imageId,omitempty"`
+	InstanceType     GcpCCInstanceType `json:"instanceType"`
+	Labels           string            `json:"labels,omitempty"`
+	// NetworkConfig holds one subnet per node: the backend requires
+	// len(NetworkConfig) == ClusterConfig.NumNodes and assigns NetworkConfig[i]
+	// to node i. For AZ-resilient clusters only NetworkConfig[0] is used as the
+	// base network and per-node subnets come from SubnetAzConfigs instead.
+	NetworkConfig   []GcpSubnetInput         `json:"networkConfig"`
+	NodeSizeGB      int                      `json:"nodeSizeGb,omitempty"`
+	ServiceAccounts []GcpServiceAccountInput `json:"serviceAccounts"`
+	SubnetAzConfigs []SubnetAzConfig         `json:"subnetAzConfigs,omitempty"`
+	TestImage       *GcpTestImage            `json:"testImage,omitempty"`
+	// VMType uses omitempty so that an unset value is dropped from the request
+	// and the backend applies its default (STANDARD). The empty string is not a
+	// valid VmType enum member and would be rejected by GraphQL enum coercion.
+	VMType VmConfigType `json:"vmType,omitempty"`
 }
 
 // GcpClusterConfig represents the cluster configuration for the GCP Cloud Cluster.
@@ -352,14 +359,16 @@ func (a API) CreateGcpCloudCluster(ctx context.Context, input CreateGcpClusterIn
 		return uuid.Nil, graphql.ResponseError(query, errors.New(payload.Data.Result.Message))
 	}
 
-	// Use regex to find the UUID in the message string.
-	match := uuidRegex.FindString(payload.Data.Result.Message)
-	jobID, err := uuid.Parse(match)
-	if err != nil {
-		return uuid.Nil, err
+	// The job's task chain UUID is embedded in the success message. Parse it
+	// best-effort: a successful call must not be reported as an error just
+	// because the message format does not contain a parseable UUID.
+	if match := uuidRegex.FindString(payload.Data.Result.Message); match != "" {
+		if jobID, err := uuid.Parse(match); err == nil {
+			return jobID, nil
+		}
 	}
 
-	return jobID, nil
+	return uuid.Nil, nil
 }
 
 // DeleteGcpCloudCluster deletes a GCP Cloud Cluster in RSC.
@@ -389,12 +398,14 @@ func (a API) DeleteGcpCloudCluster(ctx context.Context, input DeleteGcpClusterIn
 		return uuid.Nil, graphql.ResponseError(query, errors.New(payload.Data.Result.Message))
 	}
 
-	// Use regex to find the UUID in the message string.
-	match := uuidRegex.FindString(payload.Data.Result.Message)
-	jobID, err := uuid.Parse(match)
-	if err != nil {
-		return uuid.Nil, err
+	// The job's task chain UUID is embedded in the success message. Parse it
+	// best-effort: a successful call must not be reported as an error just
+	// because the message format does not contain a parseable UUID.
+	if match := uuidRegex.FindString(payload.Data.Result.Message); match != "" {
+		if jobID, err := uuid.Parse(match); err == nil {
+			return jobID, nil
+		}
 	}
 
-	return jobID, nil
+	return uuid.Nil, nil
 }

--- a/pkg/polaris/graphql/cloudcluster/cloudcluster_gcp.go
+++ b/pkg/polaris/graphql/cloudcluster/cloudcluster_gcp.go
@@ -96,10 +96,11 @@ type GcpServiceAccountInput struct {
 	Scopes []string `json:"scopes,omitempty"`
 }
 
-// SubnetAzConfig represents the subnet availability zone configuration for GCP Cloud Cluster.
-type SubnetAzConfig struct {
-	AvailabilityZone string `json:"availabilityZone,omitempty"`
-	Subnet           string `json:"subnet,omitempty"`
+// GcpTestImage represents a test image for the GCP Cloud Cluster. Used for
+// internal testing purposes only.
+type GcpTestImage struct {
+	ImageName string `json:"imageName,omitempty"`
+	Project   string `json:"project,omitempty"`
 }
 
 // GcpVmConfig represents the VM configuration for the GCP Cloud Cluster.
@@ -107,10 +108,14 @@ type GcpVmConfig struct {
 	CDMProduct       string                   `json:"cdmProduct,omitempty"`
 	CDMVersion       string                   `json:"cdmVersion,omitempty"`
 	DeleteProtection bool                     `json:"deleteProtection"`
+	ImageID          string                   `json:"imageId,omitempty"`
 	InstanceType     GcpCCInstanceType        `json:"instanceType"`
+	Labels           string                   `json:"labels,omitempty"`
 	NetworkConfig    []GcpSubnetInput         `json:"networkConfig"`
+	NodeSizeGB       int                      `json:"nodeSizeGb,omitempty"`
 	ServiceAccounts  []GcpServiceAccountInput `json:"serviceAccounts"`
 	SubnetAzConfigs  []SubnetAzConfig         `json:"subnetAzConfigs,omitempty"`
+	TestImage        *GcpTestImage            `json:"testImage,omitempty"`
 	VMType           VmConfigType             `json:"vmType"`
 }
 

--- a/pkg/polaris/graphql/cloudcluster/cloudcluster_gcp_test.go
+++ b/pkg/polaris/graphql/cloudcluster/cloudcluster_gcp_test.go
@@ -129,7 +129,7 @@ func TestCreateGcpClusterInputMarshal(t *testing.T) {
 
 	// Optional vmConfig fields must be omitted when empty so the API applies
 	// its own defaults.
-	for _, key := range []string{"imageId", "labels", "nodeSizeGb", "testImage", "subnetAzConfigs"} {
+	for _, key := range []string{"imageId", "labels", "nodeSizeGb", "testImage", "subnetAzConfigs", "vmType"} {
 		if _, ok := vmConfig[key]; ok {
 			t.Errorf("optional vmConfig key %q should be omitted when empty", key)
 		}
@@ -143,6 +143,7 @@ func TestGcpVmConfigOptionalFieldsMarshal(t *testing.T) {
 		ImageID:    "projects/p/global/images/img",
 		Labels:     "key=value",
 		NodeSizeGB: 1024,
+		VMType:     CCVmConfigDense,
 		TestImage: &GcpTestImage{
 			ImageName: "img",
 			Project:   "p",
@@ -174,5 +175,8 @@ func TestGcpVmConfigOptionalFieldsMarshal(t *testing.T) {
 	}
 	if testImage["imageName"] != "img" || testImage["project"] != "p" {
 		t.Errorf("testImage = %v", testImage)
+	}
+	if got["vmType"] != "DENSE" {
+		t.Errorf("vmType = %v, want DENSE", got["vmType"])
 	}
 }

--- a/pkg/polaris/graphql/cloudcluster/cloudcluster_gcp_test.go
+++ b/pkg/polaris/graphql/cloudcluster/cloudcluster_gcp_test.go
@@ -1,0 +1,178 @@
+// Copyright 2026 Rubrik, Inc.
+//
+// Permission is hereby granted, free of charge, to any person obtaining a copy
+// of this software and associated documentation files (the "Software"), to
+// deal in the Software without restriction, including without limitation the
+// rights to use, copy, modify, merge, publish, distribute, sublicense, and/or
+// sell copies of the Software, and to permit persons to whom the Software is
+// furnished to do so, subject to the following conditions:
+//
+// The above copyright notice and this permission notice shall be included in
+// all copies or substantial portions of the Software.
+//
+// THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+// IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+// FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+// AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+// LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING
+// FROM, OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER
+// DEALINGS IN THE SOFTWARE.
+
+package cloudcluster
+
+import (
+	"encoding/json"
+	"testing"
+
+	"github.com/google/uuid"
+)
+
+// TestCreateGcpClusterInputMarshal verifies that CreateGcpClusterInput marshals
+// to the exact wire format expected by the RSC createGcpCluster /
+// validateCreateGcpClusterInput APIs. This guards against struct tag drift,
+// which silently produces inputs the API rejects.
+func TestCreateGcpClusterInputMarshal(t *testing.T) {
+	input := CreateGcpClusterInput{
+		CloudAccountID:       uuid.MustParse("6a6a9c1a-2861-412b-ac00-b48fb74222e2"),
+		IsEsType:             true,
+		KeepClusterOnFailure: false,
+		Region:               "us-east1",
+		Zone:                 "us-east1-b",
+		Validations:          []ClusterCreateValidations{AllChecks},
+		ClusterConfig: GcpClusterConfig{
+			ClusterName:    "test-cces",
+			UserEmail:      "user@example.com",
+			AdminPassword:  "placeholder-secret",
+			DNSNameServers: []string{"8.8.8.8"},
+			NTPServers:     []string{"pool.ntp.org"},
+			NumNodes:       1,
+			GcpEsConfig: GcpEsConfigInput{
+				BucketName:         "test-bucket",
+				Region:             "us-east1",
+				ShouldCreateBucket: false,
+			},
+		},
+		VMConfig: GcpVmConfig{
+			CDMProduct:       "rubrik-9-4",
+			CDMVersion:       "9.4.2",
+			DeleteProtection: true,
+			InstanceType:     GcpInstanceTypeN2Standard8,
+			NetworkConfig: []GcpSubnetInput{{
+				HostProject: "host-proj",
+				Name:        "default",
+				Network:     "default",
+				Region:      "us-east1",
+			}},
+			ServiceAccounts: []GcpServiceAccountInput{{
+				Email:  "sa@example.com",
+				Scopes: []string{"https://www.googleapis.com/auth/cloud-platform"},
+			}},
+		},
+	}
+
+	data, err := json.Marshal(input)
+	if err != nil {
+		t.Fatalf("failed to marshal CreateGcpClusterInput: %v", err)
+	}
+
+	var got map[string]any
+	if err := json.Unmarshal(data, &got); err != nil {
+		t.Fatalf("failed to unmarshal: %v", err)
+	}
+
+	// Required top-level keys must be present with the schema's exact names.
+	for _, key := range []string{
+		"cloudAccountId", "clusterConfig", "isEsType", "keepClusterOnFailure",
+		"region", "validations", "vmConfig", "zone",
+	} {
+		if _, ok := got[key]; !ok {
+			t.Errorf("missing top-level key %q", key)
+		}
+	}
+
+	// isAzResilient is an optional pointer; it must be omitted when unset.
+	if _, ok := got["isAzResilient"]; ok {
+		t.Error("isAzResilient should be omitted when nil")
+	}
+
+	// clusterConfig: admin password must marshal to its plain value (not
+	// redacted) so it reaches the API, and the GCP ES config must be nested
+	// under gcpEsConfig with the schema field names.
+	clusterConfig, ok := got["clusterConfig"].(map[string]any)
+	if !ok {
+		t.Fatal("clusterConfig is not an object")
+	}
+	if clusterConfig["adminPassword"] != "placeholder-secret" {
+		t.Errorf("adminPassword = %v, want plain value", clusterConfig["adminPassword"])
+	}
+	esConfig, ok := clusterConfig["gcpEsConfig"].(map[string]any)
+	if !ok {
+		t.Fatal("clusterConfig.gcpEsConfig is not an object")
+	}
+	if esConfig["bucketName"] != "test-bucket" {
+		t.Errorf("gcpEsConfig.bucketName = %v, want test-bucket", esConfig["bucketName"])
+	}
+
+	// vmConfig: nested network and service account field names must match.
+	vmConfig, ok := got["vmConfig"].(map[string]any)
+	if !ok {
+		t.Fatal("vmConfig is not an object")
+	}
+	network := vmConfig["networkConfig"].([]any)[0].(map[string]any)
+	if network["hostProject"] != "host-proj" {
+		t.Errorf("networkConfig[0].hostProject = %v, want host-proj", network["hostProject"])
+	}
+	serviceAccount := vmConfig["serviceAccounts"].([]any)[0].(map[string]any)
+	if serviceAccount["email"] != "sa@example.com" {
+		t.Errorf("serviceAccounts[0].email = %v, want sa@example.com", serviceAccount["email"])
+	}
+
+	// Optional vmConfig fields must be omitted when empty so the API applies
+	// its own defaults.
+	for _, key := range []string{"imageId", "labels", "nodeSizeGb", "testImage", "subnetAzConfigs"} {
+		if _, ok := vmConfig[key]; ok {
+			t.Errorf("optional vmConfig key %q should be omitted when empty", key)
+		}
+	}
+}
+
+// TestGcpVmConfigOptionalFieldsMarshal verifies the optional vmConfig fields
+// serialize with the correct schema names when populated.
+func TestGcpVmConfigOptionalFieldsMarshal(t *testing.T) {
+	vmConfig := GcpVmConfig{
+		ImageID:    "projects/p/global/images/img",
+		Labels:     "key=value",
+		NodeSizeGB: 1024,
+		TestImage: &GcpTestImage{
+			ImageName: "img",
+			Project:   "p",
+		},
+	}
+
+	data, err := json.Marshal(vmConfig)
+	if err != nil {
+		t.Fatalf("failed to marshal GcpVmConfig: %v", err)
+	}
+
+	var got map[string]any
+	if err := json.Unmarshal(data, &got); err != nil {
+		t.Fatalf("failed to unmarshal: %v", err)
+	}
+
+	if got["imageId"] != "projects/p/global/images/img" {
+		t.Errorf("imageId = %v", got["imageId"])
+	}
+	if got["labels"] != "key=value" {
+		t.Errorf("labels = %v", got["labels"])
+	}
+	if got["nodeSizeGb"] != float64(1024) {
+		t.Errorf("nodeSizeGb = %v, want 1024", got["nodeSizeGb"])
+	}
+	testImage, ok := got["testImage"].(map[string]any)
+	if !ok {
+		t.Fatal("testImage is not an object")
+	}
+	if testImage["imageName"] != "img" || testImage["project"] != "p" {
+		t.Errorf("testImage = %v", testImage)
+	}
+}

--- a/pkg/polaris/graphql/cloudcluster/queries.go
+++ b/pkg/polaris/graphql/cloudcluster/queries.go
@@ -227,6 +227,81 @@ var createAzureCcClusterQuery = `mutation SdkGolangCreateAzureCcCluster($input: 
   }
 }`
 
+// createGcpCloudCluster GraphQL query
+var createGcpCloudClusterQuery = `mutation SdkGolangCreateGcpCloudCluster($input: CreateGcpClusterInput!) {
+  result: createGcpCluster(input: $input) {
+    jobId
+    message
+    success
+  }
+}`
+
+// deleteGcpCcCluster GraphQL query
+var deleteGcpCcClusterQuery = `mutation SdkGolangDeleteGcpCcCluster($input: DeleteGcpClusterInput!) {
+  result: deleteGcpCluster(input: $input) {
+    jobId
+    message
+    success
+  }
+}`
+
+// gcpCcBuckets GraphQL query
+var gcpCcBucketsQuery = `query SdkGolangGcpCcBuckets($input: GcpBucketsReq!) {
+  result: gcpBuckets(input: $input) {
+    buckets {
+      bucketName
+      region
+      shouldCreateBucket
+    }
+  }
+}`
+
+// gcpCcCdmVersions GraphQL query
+var gcpCcCdmVersionsQuery = `query SdkGolangGcpCcCdmVersions($input: GcpCdmVersionReq!) {
+  result: gcpCdmVersions(input: $input) {
+    cdmVersions {
+      cdmVersion
+      cdmProduct
+      imageId
+      isLatest
+      supportedInstanceTypes
+    }
+  }
+}`
+
+// gcpCcRegions GraphQL query
+var gcpCcRegionsQuery = `query SdkGolangGcpCcRegions($input: GcpRegionsReq!) {
+  result: gcpRegions(input: $input) {
+    gcpRegions {
+      name
+      zones
+    }
+  }
+}`
+
+// gcpCcServiceAccounts GraphQL query
+var gcpCcServiceAccountsQuery = `query SdkGolangGcpCcServiceAccounts($input: GcpServiceAccountReq!) {
+  result: gcpServiceAccounts(input: $input) {
+    serviceAccounts {
+      email
+      name
+      scopes
+    }
+  }
+}`
+
+// gcpCcSubnets GraphQL query
+var gcpCcSubnetsQuery = `query SdkGolangGcpCcSubnets($input: GcpSubnetReq!) {
+  result: gcpSubnets(input: $input) {
+    subnets {
+      hostProject
+      name
+      network
+      region
+    }
+  }
+}`
+
 // removeAwsCcCluster GraphQL query
 var removeAwsCcClusterQuery = `mutation SdkGolangRemoveAwsCcCluster(
   $clusterUuid: UUID!
@@ -251,6 +326,14 @@ var validateAwsClusterCreateRequestQuery = `query SdkGolangValidateAwsClusterCre
 // validateAzureClusterCreateRequest GraphQL query
 var validateAzureClusterCreateRequestQuery = `query SdkGolangValidateAzureClusterCreateRequest($input: CreateAzureClusterInput!) {
   result: validateCreateAzureClusterInput(input: $input) {
+    message
+    isSuccessful
+  }
+}`
+
+// validateGcpClusterCreateRequest GraphQL query
+var validateGcpClusterCreateRequestQuery = `query SdkGolangValidateGcpClusterCreateRequest($input: CreateGcpClusterInput!) {
+  result: validateCreateGcpClusterInput(input: $input) {
     message
     isSuccessful
   }

--- a/pkg/polaris/graphql/cloudcluster/queries/create_gcp_cloud_cluster.graphql
+++ b/pkg/polaris/graphql/cloudcluster/queries/create_gcp_cloud_cluster.graphql
@@ -1,0 +1,7 @@
+mutation RubrikPolarisSDKRequest($input: CreateGcpClusterInput!) {
+  result: createGcpCluster(input: $input) {
+    jobId
+    message
+    success
+  }
+}

--- a/pkg/polaris/graphql/cloudcluster/queries/delete_gcp_cc_cluster.graphql
+++ b/pkg/polaris/graphql/cloudcluster/queries/delete_gcp_cc_cluster.graphql
@@ -1,0 +1,7 @@
+mutation RubrikPolarisSDKRequest($input: DeleteGcpClusterInput!) {
+  result: deleteGcpCluster(input: $input) {
+    jobId
+    message
+    success
+  }
+}

--- a/pkg/polaris/graphql/cloudcluster/queries/gcp_cc_buckets.graphql
+++ b/pkg/polaris/graphql/cloudcluster/queries/gcp_cc_buckets.graphql
@@ -1,0 +1,9 @@
+query RubrikPolarisSDKRequest($input: GcpBucketsReq!) {
+  result: gcpBuckets(input: $input) {
+    buckets {
+      bucketName
+      region
+      shouldCreateBucket
+    }
+  }
+}

--- a/pkg/polaris/graphql/cloudcluster/queries/gcp_cc_cdm_versions.graphql
+++ b/pkg/polaris/graphql/cloudcluster/queries/gcp_cc_cdm_versions.graphql
@@ -1,0 +1,11 @@
+query RubrikPolarisSDKRequest($input: GcpCdmVersionReq!) {
+  result: gcpCdmVersions(input: $input) {
+    cdmVersions {
+      cdmVersion
+      cdmProduct
+      imageId
+      isLatest
+      supportedInstanceTypes
+    }
+  }
+}

--- a/pkg/polaris/graphql/cloudcluster/queries/gcp_cc_regions.graphql
+++ b/pkg/polaris/graphql/cloudcluster/queries/gcp_cc_regions.graphql
@@ -1,0 +1,8 @@
+query RubrikPolarisSDKRequest($input: GcpRegionsReq!) {
+  result: gcpRegions(input: $input) {
+    gcpRegions {
+      name
+      zones
+    }
+  }
+}

--- a/pkg/polaris/graphql/cloudcluster/queries/gcp_cc_service_accounts.graphql
+++ b/pkg/polaris/graphql/cloudcluster/queries/gcp_cc_service_accounts.graphql
@@ -1,0 +1,9 @@
+query RubrikPolarisSDKRequest($input: GcpServiceAccountReq!) {
+  result: gcpServiceAccounts(input: $input) {
+    serviceAccounts {
+      email
+      name
+      scopes
+    }
+  }
+}

--- a/pkg/polaris/graphql/cloudcluster/queries/gcp_cc_subnets.graphql
+++ b/pkg/polaris/graphql/cloudcluster/queries/gcp_cc_subnets.graphql
@@ -1,0 +1,10 @@
+query RubrikPolarisSDKRequest($input: GcpSubnetReq!) {
+  result: gcpSubnets(input: $input) {
+    subnets {
+      hostProject
+      name
+      network
+      region
+    }
+  }
+}

--- a/pkg/polaris/graphql/cloudcluster/queries/validate_gcp_cluster_create_request.graphql
+++ b/pkg/polaris/graphql/cloudcluster/queries/validate_gcp_cluster_create_request.graphql
@@ -1,0 +1,6 @@
+query RubrikPolarisSDKRequest($input: CreateGcpClusterInput!) {
+  result: validateCreateGcpClusterInput(input: $input) {
+    message
+    isSuccessful
+  }
+}


### PR DESCRIPTION
## Summary
Adds GCP Cloud Cluster Elastic Storage (CCES) support to the SDK: the GraphQL
queries/mutations and high-level `CreateGcpCloudCluster` / `DeleteGcpCloudCluster`
API, plus helpers for regions, zones, CDM versions, subnets, service accounts,
and buckets.

This incorporates the GCP CCES work originally proposed in #335, rebased onto
current `main`, and adds:
- The optional `GcpVmConfigInput` schema fields that were missing (`imageId`,
  `labels`, `nodeSizeGb`, `testImage`).
- Client-side validation that mirrors the RSC provisioning wizard so misconfig
  fails fast before the API round-trip:
  - GCS bucket region must match the cluster region (case-insensitive).
  - Cluster zone must belong to the selected region.
  - AZ-resilient clusters require a region with at least three zones, at least
    three nodes, and each resiliency subnet zone to belong to the region.
- Unit tests for the input wire format and the validation gates.

The `SubnetAzConfig` type that landed on `main` for Multi-AZ is reused rather
than duplicated.

## Testing
- `go build`, `go vet`, `staticcheck`, `gofmt`, and `go test ./...` all pass
  (full suite green in a clean environment).
- The GraphQL operations, input types, request payloads, and response parsing
  were validated against a captured end-to-end provisioning trace (regions,
  CDM versions, service accounts, subnets, buckets, validate, and create). All
  operation names, input shapes, and response field names match, including the
  distinct `isSuccessful` (validate) vs `success` (create) reply fields and the
  job identifier that is carried in the create reply message.
- A live provisioning round-trip is still pending due to a cloud-account
  restriction in the test environment.