### PR TITLE
Fix vmType empty-enum and align dynamic-scaling CDM minimum

### DIFF
--- a/pkg/polaris/cloudcluster/cloudcluster.go
+++ b/pkg/polaris/cloudcluster/cloudcluster.go
@@ -115,14 +115,14 @@ func (a API) CreateCloudCluster(ctx context.Context, input cloudcluster.CreateAw
 		return CloudCluster{}, fmt.Errorf("cdm version %s is not available for account %s", input.VMConfig.CDMVersion, account.ID)
 	}
 
-	// Validate dynamic scaling is only enabled for CDM version 9.5 or higher
+	// Validate dynamic scaling is only enabled for a supported CDM version.
 	if input.ClusterConfig.DynamicScalingEnabled {
 		cdmVersion, err := polcluster.ParseCDMVersion(input.VMConfig.CDMVersion)
 		if err != nil {
 			return CloudCluster{}, fmt.Errorf("failed to parse CDM version %s: %s", input.VMConfig.CDMVersion, err)
 		}
-		if cdmVersion.LessThan("9.5") {
-			return CloudCluster{}, fmt.Errorf("dynamic scaling requires CDM version 9.5 or higher, got %s", input.VMConfig.CDMVersion)
+		if cdmVersion.LessThan(minCDMVersionDynamicScaling) {
+			return CloudCluster{}, fmt.Errorf("dynamic scaling requires CDM version %s or higher, got %s", minCDMVersionDynamicScaling, input.VMConfig.CDMVersion)
 		}
 	}
 
@@ -454,10 +454,10 @@ func validateGcpZones(input cloudcluster.CreateGcpClusterInput, regionZones []st
 	return nil
 }
 
-// minCDMVersionGcpDynamicScaling is the minimum CDM version that supports
-// dynamic scaling. It matches the RSC UI's MIN_CDM_VERSION_DYNAMIC_SCALING_ENABLED
-// constant.
-const minCDMVersionGcpDynamicScaling = "9.4.3"
+// minCDMVersionDynamicScaling is the minimum CDM version that supports dynamic
+// scaling. It matches the RSC UI's MIN_CDM_VERSION_DYNAMIC_SCALING_ENABLED
+// constant and applies across cloud providers.
+const minCDMVersionDynamicScaling = "9.4.3"
 
 // minMultiAzZones is the minimum number of zones, nodes, and resiliency subnets
 // required for an AZ-resilient GCP cluster. It matches the backend's
@@ -523,8 +523,8 @@ func (a API) CreateGcpCloudCluster(ctx context.Context, input cloudcluster.Creat
 		if err != nil {
 			return CloudCluster{}, fmt.Errorf("failed to parse CDM version %s: %s", input.VMConfig.CDMVersion, err)
 		}
-		if cdmVersion.LessThan(minCDMVersionGcpDynamicScaling) {
-			return CloudCluster{}, fmt.Errorf("dynamic scaling requires CDM version %s or higher, got %s", minCDMVersionGcpDynamicScaling, input.VMConfig.CDMVersion)
+		if cdmVersion.LessThan(minCDMVersionDynamicScaling) {
+			return CloudCluster{}, fmt.Errorf("dynamic scaling requires CDM version %s or higher, got %s", minCDMVersionDynamicScaling, input.VMConfig.CDMVersion)
 		}
 	}
 

--- a/pkg/polaris/graphql/cloudcluster/cloudcluster_aws.go
+++ b/pkg/polaris/graphql/cloudcluster/cloudcluster_aws.go
@@ -238,8 +238,11 @@ type AwsVmConfig struct {
 	SecurityGroups      []string          `json:"securityGroups"`
 	Subnet              string            `json:"subnet,omitempty"`
 	SubnetAzConfigs     []SubnetAzConfig  `json:"subnetAzConfigs,omitempty"`
-	VMType              VmConfigType      `json:"vmType"`
-	VPC                 string            `json:"vpc"`
+	// VMType uses omitempty so that an unset value is dropped from the request
+	// and the backend applies its default (STANDARD). The empty string is not a
+	// valid VmType enum member and would be rejected by GraphQL enum coercion.
+	VMType VmConfigType `json:"vmType,omitempty"`
+	VPC    string       `json:"vpc"`
 }
 
 type AwsClusterConfig struct {

--- a/pkg/polaris/graphql/cloudcluster/cloudcluster_azure.go
+++ b/pkg/polaris/graphql/cloudcluster/cloudcluster_azure.go
@@ -285,10 +285,13 @@ type AzureClusterConfig struct {
 
 // AzureVMConfig represents the VM configuration for the Azure Cloud Cluster.
 type AzureVMConfig struct {
-	CDMVersion                   string                         `json:"cdmVersion"`
-	Subnet                       string                         `json:"subnet,omitempty"`
-	SubnetAzConfigs              []SubnetAzConfig               `json:"subnetAzConfigs,omitempty"`
-	VMType                       VmConfigType                   `json:"vmType"`
+	CDMVersion      string           `json:"cdmVersion"`
+	Subnet          string           `json:"subnet,omitempty"`
+	SubnetAzConfigs []SubnetAzConfig `json:"subnetAzConfigs,omitempty"`
+	// VMType uses omitempty so that an unset value is dropped from the request
+	// and the backend applies its default (STANDARD). The empty string is not a
+	// valid VmType enum member and would be rejected by GraphQL enum coercion.
+	VMType                       VmConfigType                   `json:"vmType,omitempty"`
 	CDMProduct                   string                         `json:"cdmProduct"`
 	Location                     azure.Region                   `json:"location"`
 	AvailabilityZone             string                         `json:"availabilityZone,omitempty"`

--- a/pkg/polaris/graphql/cloudcluster/cloudcluster_vmtype_test.go
+++ b/pkg/polaris/graphql/cloudcluster/cloudcluster_vmtype_test.go
@@ -1,0 +1,66 @@
+// Copyright 2026 Rubrik, Inc.
+//
+// Permission is hereby granted, free of charge, to any person obtaining a copy
+// of this software and associated documentation files (the "Software"), to
+// deal in the Software without restriction, including without limitation the
+// rights to use, copy, modify, merge, publish, distribute, sublicense, and/or
+// sell copies of the Software, and to permit persons to whom the Software is
+// furnished to do so, subject to the following conditions:
+//
+// The above copyright notice and this permission notice shall be included in
+// all copies or substantial portions of the Software.
+//
+// THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+// IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+// FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+// AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+// LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING
+// FROM, OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER
+// DEALINGS IN THE SOFTWARE.
+
+package cloudcluster
+
+import (
+	"encoding/json"
+	"testing"
+)
+
+// TestVMTypeOmittedWhenEmpty verifies that an unset VMType is dropped from the
+// request for every provider's VM config. The empty string is not a valid
+// VmType enum member and would be rejected by GraphQL enum coercion, so it must
+// be omitted to let the backend apply its default.
+func TestVMTypeOmittedWhenEmpty(t *testing.T) {
+	tests := map[string]any{
+		"aws":   AwsVmConfig{},
+		"azure": AzureVMConfig{},
+	}
+
+	for name, vmConfig := range tests {
+		t.Run(name, func(t *testing.T) {
+			data, err := json.Marshal(vmConfig)
+			if err != nil {
+				t.Fatalf("failed to marshal: %v", err)
+			}
+			var got map[string]any
+			if err := json.Unmarshal(data, &got); err != nil {
+				t.Fatalf("failed to unmarshal: %v", err)
+			}
+			if _, ok := got["vmType"]; ok {
+				t.Errorf("vmType should be omitted when empty, got %v", got["vmType"])
+			}
+		})
+	}
+
+	// When set, vmType must serialize.
+	data, err := json.Marshal(AwsVmConfig{VMType: CCVmConfigStandard})
+	if err != nil {
+		t.Fatalf("failed to marshal: %v", err)
+	}
+	var got map[string]any
+	if err := json.Unmarshal(data, &got); err != nil {
+		t.Fatalf("failed to unmarshal: %v", err)
+	}
+	if got["vmType"] != "STANDARD" {
+		t.Errorf("vmType = %v, want STANDARD", got["vmType"])
+	}
+}


### PR DESCRIPTION
## Summary
Follow-up consistency fixes for cloud cluster support, applying to the AWS and
Azure siblings the same corrections made for GCP CCES.

- **vmType empty enum:** add `omitempty` to `VMType` on the AWS and Azure VM
  configs. The zero value serializes as `""`, which is not a valid `VmType` enum
  member and is rejected by GraphQL enum coercion; with `omitempty` an unset
  value is dropped and the backend applies its default (`STANDARD`). GCP was
  already fixed when CCES support landed.
- **Dynamic-scaling CDM minimum:** lower the threshold from `9.5` to `9.4.3` to
  match the RSC UI (`MIN_CDM_VERSION_DYNAMIC_SCALING_ENABLED`), and share a
  single `minCDMVersionDynamicScaling` constant across the AWS and GCP paths
  instead of a literal.

## Testing
- `go build`, `go vet`, `staticcheck`, `gofmt` clean; full suite `go test ./...`
  passes.
- Added a marshaling test asserting `vmType` is omitted when empty for the AWS
  and Azure VM configs and serializes when set.