### PR TITLE
Filter CROSSACCOUNT artifact for role chaining

### DIFF
--- a/pkg/polaris/aws/cloud_account_iam.go
+++ b/pkg/polaris/aws/cloud_account_iam.go
@@ -168,6 +168,7 @@ func (a API) removeAccountWithIAM(ctx context.Context, account CloudAccount, fea
 }
 
 const (
+	crossAccountArtifact  = "CROSSACCOUNT"
 	roleArnSuffix         = "_ROLE_ARN"
 	instanceProfileSuffix = "_INSTANCE_PROFILE"
 )
@@ -209,6 +210,16 @@ func (a API) Artifacts(ctx context.Context, cloud string, features []core.Featur
 		return roles[i] < roles[j]
 	})
 
+	// Workaround: RSC currently returns an empty CROSSACCOUNT role artifact
+	// for role-chaining accounts. Drop it so callers don't create a spurious
+	// cross-account role. Remove the workaround once RSC stops returning the
+	// duplicate artifact.
+	if len(features) == 1 && features[0].Equal(core.FeatureRoleChaining) {
+		roles = slices.DeleteFunc(roles, func(role string) bool {
+			return role == crossAccountArtifact
+		})
+	}
+
 	return profiles, roles, nil
 }
 
@@ -244,6 +255,14 @@ func (a API) AccountArtifacts(ctx context.Context, cloudAccountID uuid.UUID) (ma
 		}
 	}
 	a.log.Printf(log.Debug, "Skipped the following artifacts: %v", skipped)
+
+	// Workaround: RSC returns the role-chaining role ARN under both the
+	// CROSSACCOUNT and ROLE_CHAINING artifacts. Drop the CROSSACCOUNT artifact
+	// so it doesn't appear in the registered artifacts. Remove the workaround
+	// once RSC stops returning the duplicate artifact.
+	if len(account.Features) == 1 && account.Features[0].Equal(core.FeatureRoleChaining) {
+		delete(roles, crossAccountArtifact)
+	}
 
 	return instanceProfiles, roles, nil
 }

--- a/pkg/polaris/aws/cloud_account_iam_test.go
+++ b/pkg/polaris/aws/cloud_account_iam_test.go
@@ -1,0 +1,164 @@
+// Copyright 2026 Rubrik, Inc.
+//
+// Permission is hereby granted, free of charge, to any person obtaining a copy
+// of this software and associated documentation files (the "Software"), to
+// deal in the Software without restriction, including without limitation the
+// rights to use, copy, modify, merge, publish, distribute, sublicense, and/or
+// sell copies of the Software, and to permit persons to whom the Software is
+// furnished to do so, subject to the following conditions:
+//
+// The above copyright notice and this permission notice shall be included in
+// all copies or substantial portions of the Software.
+//
+// THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+// IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+// FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+// AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+// LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING
+// FROM, OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER
+// DEALINGS IN THE SOFTWARE.
+
+package aws
+
+import (
+	"context"
+	"encoding/json"
+	"fmt"
+	"io"
+	"net/http"
+	"net/http/httptest"
+	"slices"
+	"strings"
+	"testing"
+
+	"github.com/google/uuid"
+	"github.com/rubrikinc/rubrik-polaris-sdk-for-go/internal/assert"
+	"github.com/rubrikinc/rubrik-polaris-sdk-for-go/internal/handler"
+	"github.com/rubrikinc/rubrik-polaris-sdk-for-go/pkg/polaris"
+	"github.com/rubrikinc/rubrik-polaris-sdk-for-go/pkg/polaris/graphql"
+	"github.com/rubrikinc/rubrik-polaris-sdk-for-go/pkg/polaris/graphql/aws"
+	"github.com/rubrikinc/rubrik-polaris-sdk-for-go/pkg/polaris/graphql/core"
+)
+
+// mockClient returns a polaris.Client whose GraphQL requests are served by the
+// given test server.
+func mockClient(srv *httptest.Server) *polaris.Client {
+	return &polaris.Client{GQL: graphql.NewTestClient(srv)}
+}
+
+// TestArtifactsFiltersForRoleChaining verifies that the CROSSACCOUNT role
+// artifact is dropped for the role-chaining-only feature set but kept for other
+// feature sets. Part of a workaround due to issues with the RSC GraphQL API.
+func TestArtifactsFiltersForRoleChaining(t *testing.T) {
+	ctx, cancel := context.WithCancelCause(context.Background())
+	defer assert.Context(t, ctx, cancel)
+
+	srv := httptest.NewServer(handler.GraphQL(func(w http.ResponseWriter, req *http.Request) {
+		if _, err := fmt.Fprint(w, `{"data":{"result":[
+			{"externalArtifactKey":"CROSSACCOUNT_ROLE_ARN","awsManagedPolicies":[],"customerManagedPolicies":[]},
+			{"externalArtifactKey":"ROLE_CHAINING_ROLE_ARN","awsManagedPolicies":[],"customerManagedPolicies":[]}
+		]}}`); err != nil {
+			cancel(err)
+		}
+	}))
+	defer srv.Close()
+
+	tests := []struct {
+		name     string
+		features []core.Feature
+		expected []string
+	}{{
+		name:     "role chaining only drops CROSSACCOUNT",
+		features: []core.Feature{core.FeatureRoleChaining},
+		expected: []string{"ROLE_CHAINING"},
+	}, {
+		name:     "non role chaining keeps CROSSACCOUNT",
+		features: []core.Feature{core.FeatureCloudNativeProtection},
+		expected: []string{"CROSSACCOUNT", "ROLE_CHAINING"},
+	}}
+	for _, tc := range tests {
+		t.Run(tc.name, func(t *testing.T) {
+			_, roles, err := Wrap(mockClient(srv)).Artifacts(ctx, string(aws.CloudStandard), tc.features)
+			if err != nil {
+				t.Fatal(err)
+			}
+			if !slices.Equal(roles, tc.expected) {
+				t.Errorf("expected roles %v, got %v", tc.expected, roles)
+			}
+		})
+	}
+}
+
+// TestAccountArtifactsFiltersForRoleChaining verifies that the registered
+// CROSSACCOUNT role artifact is dropped for role-chaining-only accounts but
+// kept for other accounts. Part of a workaround due to issues with the RSC
+// GraphQL API.
+func TestAccountArtifactsFiltersForRoleChaining(t *testing.T) {
+	tests := []struct {
+		name             string
+		feature          string
+		wantCrossAccount bool
+	}{{
+		name:             "role chaining only drops CROSSACCOUNT",
+		feature:          core.FeatureRoleChaining.Name,
+		wantCrossAccount: false,
+	}, {
+		name:             "non role chaining keeps CROSSACCOUNT",
+		feature:          core.FeatureCloudNativeProtection.Name,
+		wantCrossAccount: true,
+	}}
+	for _, tc := range tests {
+		t.Run(tc.name, func(t *testing.T) {
+			ctx, cancel := context.WithCancelCause(context.Background())
+			defer assert.Context(t, ctx, cancel)
+
+			srv := httptest.NewServer(handler.GraphQL(func(w http.ResponseWriter, req *http.Request) {
+				buf, err := io.ReadAll(req.Body)
+				if err != nil {
+					cancel(err)
+					return
+				}
+				var payload struct {
+					Query string `json:"query"`
+				}
+				if err := json.Unmarshal(buf, &payload); err != nil {
+					cancel(err)
+					return
+				}
+				switch {
+				case strings.Contains(payload.Query, "allAwsCloudAccountsWithFeatures"):
+					if _, err := fmt.Fprintf(w, `{"data":{"result":[
+						{"awsCloudAccount":{"cloudType":"STANDARD","id":"b48e7ad0-7b86-4c96-b6ba-97eb6a82f765","nativeId":"123456789012","accountName":"test","message":""},
+						 "featureDetails":[{"feature":%q,"permissionsGroups":[],"awsRegions":[],"roleArn":"","stackArn":"","status":"CONNECTED","mappedAccounts":[],"roleChainingDetails":null}],
+						 "roleChainingAccount":null}
+					]}}`, tc.feature); err != nil {
+						cancel(err)
+					}
+				case strings.Contains(payload.Query, "awsArtifactsToDelete"):
+					if _, err := fmt.Fprint(w, `{"data":{"result":{"artifactsToDelete":[
+						{"feature":"ROLE_CHAINING","artifactsToDelete":[
+							{"externalArtifactKey":"CROSSACCOUNT_ROLE_ARN","externalArtifactValue":"arn:aws:iam::123456789012:role/chain"},
+							{"externalArtifactKey":"ROLE_CHAINING_ROLE_ARN","externalArtifactValue":"arn:aws:iam::123456789012:role/chain"}
+						]}
+					]}}}`); err != nil {
+						cancel(err)
+					}
+				default:
+					cancel(fmt.Errorf("unexpected query: %s", payload.Query))
+				}
+			}))
+			defer srv.Close()
+
+			_, roles, err := Wrap(mockClient(srv)).AccountArtifacts(ctx, uuid.MustParse("b48e7ad0-7b86-4c96-b6ba-97eb6a82f765"))
+			if err != nil {
+				t.Fatal(err)
+			}
+			if _, ok := roles[crossAccountArtifact]; ok != tc.wantCrossAccount {
+				t.Errorf("CROSSACCOUNT present=%v, want %v (roles=%v)", ok, tc.wantCrossAccount, roles)
+			}
+			if _, ok := roles["ROLE_CHAINING"]; !ok {
+				t.Errorf("expected ROLE_CHAINING to be present (roles=%v)", roles)
+			}
+		})
+	}
+}


### PR DESCRIPTION
# Description

Filter out the spurious `CROSSACCOUNT` role artifact that RSC returns for role-chaining-only cloud accounts. The fix is applied in both `Artifacts()` and `AccountArtifacts()`, gated on the account having the single `ROLE_CHAINING` feature, and is intentionally kept as a post-build step outside the main logic so it can be removed cleanly once the backend is fixed.

## Related Issue

No tracking issue exists for this change.

## Motivation and Context

For a role-chaining-only account RSC returns a `CROSSACCOUNT` role artifact alongside the genuine `ROLE_CHAINING` artifact, both resolving to the role-chaining role. Consumers (the Terraform provider) would otherwise create and register a redundant cross-account role, and reading the registered artifacts back produced a perpetual diff. Dropping the duplicate artifact at the SDK boundary keeps callers from acting on it. This is a temporary workaround until RSC stops returning the duplicate.

## How Has This Been Tested?

* Added table-driven unit tests (`cloud_account_iam_test.go`) using a mock GraphQL handler, covering both `Artifacts()` and `AccountArtifacts()` for the role-chaining-only feature set (CROSSACCOUNT dropped) and a non-role-chaining feature set (CROSSACCOUNT kept).
* `go test ./pkg/polaris/aws/`, `go vet`, and `gofmt` all pass.
* Validated end-to-end through the `terraform-provider-rubrik` role-chaining acceptance test against a live RSC deployment: a single ROLE_CHAINING role is onboarded and registered with no perpetual diff.
* Testing environment: macOS arm64, Go toolchain.

## Screenshots (if appropriate):

## Types of changes

What types of changes does your code introduce? Put an `x` in all the boxes that apply:
- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)
- [ ] Other (please describe in the Description above)

## Checklist:

Go over all the following points, and put an `x` in all the boxes that apply. If you're unsure about any of these, don't hesitate to ask. We're here to help!
- [x] My code follows the code style of this project.
- [ ] My change requires a change to the documentation.
- [ ] I have updated the documentation accordingly.
- [ ] I have updated the CHANGELOG file accordingly for the version that this merge modifies.
- [x] I have added tests to cover my changes.
- [x] All new and existing tests passed.
