### PR TITLE
Add REL_ENABLE_AWS_MANUAL_ROLE_CHAINING feature flag

### DIFF
--- a/pkg/polaris/graphql/core/feature_flag.go
+++ b/pkg/polaris/graphql/core/feature_flag.go
@@ -33,6 +33,7 @@ import (
 type FeatureFlagName string
 
 const (
+	FeatureFlagAWSManualRoleChaining           FeatureFlagName = "REL_ENABLE_AWS_MANUAL_ROLE_CHAINING"
 	FeatureFlagAzureSQLDBCopyBackup            FeatureFlagName = "CNP_AZURE_SQL_DB_COPY_BACKUP"
 	FeatureFlagMultipleKeyValuePairsInTagRules FeatureFlagName = "CNP_MULTIPLE_KEY_VALUE_PAIRS_IN_TAG_RULES_ENABLED"
 )


### PR DESCRIPTION
# Description

Adds the `FeatureFlagAWSManualRoleChaining` constant (`REL_ENABLE_AWS_MANUAL_ROLE_CHAINING`) to the `core` package so callers can gate behavior on the AWS manual role chaining feature flag instead of hardcoding the flag string.

## Related Issue

No linked issue. This adds a feature-flag constant consumed by the terraform-provider-rubrik role-chaining acceptance tests.

## Motivation and Context

The terraform-provider-rubrik acceptance tests skip AWS manual role chaining cases unless the backend feature flag is enabled. Defining the flag name as an exported SDK constant keeps the canonical flag string in the SDK and lets the provider reference it rather than duplicating the literal.

## How Has This Been Tested?

Constant-only addition with no behavioral change. Verified the SDK builds and vets cleanly (`go build ./...`, `go vet ./...`).

## Screenshots (if appropriate):

## Types of changes
- [x] New feature (non-breaking change which adds functionality)
- [ ] Bug fix (non-breaking change which fixes an issue)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)
- [ ] Other (please describe in the Description above)

## Checklist:
- [x] My code follows the code style of this project.
- [ ] My change requires a change to the documentation.
- [ ] I have updated the documentation accordingly.
- [ ] I have updated the CHANGELOG file accordingly for the version that this merge modifies.
- [ ] I have added tests to cover my changes.
- [X] All new and existing tests passed.
