### PR TITLE
Add Azure SQL V1/V2 SLA support to global SLA domain

### DIFF
--- a/pkg/polaris/graphql/sla/queries.go
+++ b/pkg/polaris/graphql/sla/queries.go
@@ -161,6 +161,7 @@ var slaDomainQuery = `query SdkGolangSlaDomain($slaDomainId: UUID!) {
     }
 }
 fragment GlobalSlaReplyFields on GlobalSlaReply {
+    backupType
     archivalSpecs {
         frequencies
         threshold
@@ -242,9 +243,43 @@ fragment GlobalSlaReplyFields on GlobalSlaReply {
         }
         azureSqlDatabaseDbConfig {
             logRetentionInDays
+            ltrConfig {
+                weeklyBackupRetention {
+                    retention
+                    retentionUnit
+                }
+                monthlyBackupRetention {
+                    retention
+                    retentionUnit
+                }
+                yearlyBackupRetention {
+                    ltrRetention {
+                        retention
+                        retentionUnit
+                    }
+                    weekOfYear
+                }
+            }
         }
         azureSqlManagedInstanceDbConfig {
             logRetentionInDays
+            ltrConfig {
+                weeklyBackupRetention {
+                    retention
+                    retentionUnit
+                }
+                monthlyBackupRetention {
+                    retention
+                    retentionUnit
+                }
+                yearlyBackupRetention {
+                    ltrRetention {
+                        retention
+                        retentionUnit
+                    }
+                    weekOfYear
+                }
+            }
         }
         vmwareVmConfig {
             logRetentionSeconds
@@ -508,6 +543,7 @@ var slaDomainsQuery = `query SdkGolangSlaDomains($after: String, $filter: [Globa
     }
 }
 fragment GlobalSlaReplyFields on GlobalSlaReply {
+    backupType
     archivalSpecs {
         frequencies
         threshold
@@ -589,9 +625,43 @@ fragment GlobalSlaReplyFields on GlobalSlaReply {
         }
         azureSqlDatabaseDbConfig {
             logRetentionInDays
+            ltrConfig {
+                weeklyBackupRetention {
+                    retention
+                    retentionUnit
+                }
+                monthlyBackupRetention {
+                    retention
+                    retentionUnit
+                }
+                yearlyBackupRetention {
+                    ltrRetention {
+                        retention
+                        retentionUnit
+                    }
+                    weekOfYear
+                }
+            }
         }
         azureSqlManagedInstanceDbConfig {
             logRetentionInDays
+            ltrConfig {
+                weeklyBackupRetention {
+                    retention
+                    retentionUnit
+                }
+                monthlyBackupRetention {
+                    retention
+                    retentionUnit
+                }
+                yearlyBackupRetention {
+                    ltrRetention {
+                        retention
+                        retentionUnit
+                    }
+                    weekOfYear
+                }
+            }
         }
         vmwareVmConfig {
             logRetentionSeconds

--- a/pkg/polaris/graphql/sla/queries/global_sla_reply.fragment
+++ b/pkg/polaris/graphql/sla/queries/global_sla_reply.fragment
@@ -1,4 +1,5 @@
 fragment GlobalSlaReplyFields on GlobalSlaReply {
+    backupType
     archivalSpecs {
         frequencies
         threshold
@@ -80,9 +81,43 @@ fragment GlobalSlaReplyFields on GlobalSlaReply {
         }
         azureSqlDatabaseDbConfig {
             logRetentionInDays
+            ltrConfig {
+                weeklyBackupRetention {
+                    retention
+                    retentionUnit
+                }
+                monthlyBackupRetention {
+                    retention
+                    retentionUnit
+                }
+                yearlyBackupRetention {
+                    ltrRetention {
+                        retention
+                        retentionUnit
+                    }
+                    weekOfYear
+                }
+            }
         }
         azureSqlManagedInstanceDbConfig {
             logRetentionInDays
+            ltrConfig {
+                weeklyBackupRetention {
+                    retention
+                    retentionUnit
+                }
+                monthlyBackupRetention {
+                    retention
+                    retentionUnit
+                }
+                yearlyBackupRetention {
+                    ltrRetention {
+                        retention
+                        retentionUnit
+                    }
+                    weekOfYear
+                }
+            }
         }
         vmwareVmConfig {
             logRetentionSeconds

--- a/pkg/polaris/graphql/sla/sla_domain.go
+++ b/pkg/polaris/graphql/sla/sla_domain.go
@@ -136,10 +136,51 @@ type AWSRDSConfig struct {
 }
 
 // AzureDBConfig represents the configuration specific for an Azure database
-// object.
+// object (Azure SQL Database or Azure SQL Managed Instance).
+//
+// A V1 (Azure-managed, long-term retention) SLA carries a non-nil LTRConfig; a
+// V2 (Rubrik-managed) SLA leaves it nil. Backup locations for V2 SLAs are
+// supplied through the SLA-level BackupLocationSpecs (see CreateDomainParams),
+// matching the multiple-backup-location mechanism used by other object types.
 type AzureDBConfig struct {
-	LogRetentionInDays int `json:"logRetentionInDays"`
+	LogRetentionInDays int                `json:"logRetentionInDays"`
+	LTRConfig          *AzureSQLLTRConfig `json:"ltrConfig,omitempty"`
 }
+
+// AzureSQLLTRRetention represents a single Azure SQL long-term retention value.
+// Valid retentions are 0 or between 7 and 3650 days (Azure LTR limits). The
+// RetentionUnit is one of Days, Weeks, Months or Years.
+type AzureSQLLTRRetention struct {
+	Retention     int           `json:"retention"`
+	RetentionUnit RetentionUnit `json:"retentionUnit"`
+}
+
+// AzureSQLYearlyLTRRetention represents the yearly Azure SQL long-term
+// retention, including which week of the year to keep as the yearly backup.
+type AzureSQLYearlyLTRRetention struct {
+	Retention  AzureSQLLTRRetention `json:"ltrRetention"`
+	WeekOfYear int                  `json:"weekOfYear"`
+}
+
+// AzureSQLLTRConfig holds the long-term retention configuration for a V1
+// (Azure-managed) Azure SQL SLA. Its presence marks an SLA as V1.
+type AzureSQLLTRConfig struct {
+	WeeklyBackupRetention  *AzureSQLLTRRetention       `json:"weeklyBackupRetention,omitempty"`
+	MonthlyBackupRetention *AzureSQLLTRRetention       `json:"monthlyBackupRetention,omitempty"`
+	YearlyBackupRetention  *AzureSQLYearlyLTRRetention `json:"yearlyBackupRetention,omitempty"`
+}
+
+// BackupType identifies which system manages an SLA's Azure SQL backups,
+// distinguishing V1 (Azure-managed / LTR) from V2 (Rubrik-managed) SLAs. It is a
+// read-only value on the global SLA domain reply.
+type BackupType string
+
+const (
+	// BackupTypeNative indicates Azure-managed (V1 / LTR) backups.
+	BackupTypeNative BackupType = "NATIVE"
+	// BackupTypeRubrik indicates Rubrik-managed (V2) backups.
+	BackupTypeRubrik BackupType = "RUBRIK"
+)
 
 // VMwareVMConfig represents the configuration specific for a VMware vSphere VM
 // object.

--- a/pkg/polaris/graphql/sla/sla_domain_list.go
+++ b/pkg/polaris/graphql/sla/sla_domain_list.go
@@ -60,7 +60,10 @@ type Domain struct {
 			TierExistingSnapshots          bool             `json:"shouldTierExistingSnapshots"`
 		} `json:"archivalTieringSpec"`
 	} `json:"archivalSpecs"`
-	Archived            bool `json:"isArchived"`
+	Archived bool `json:"isArchived"`
+	// BackupType distinguishes V1 (Azure-managed / LTR, "NATIVE") from V2
+	// (Rubrik-managed) Azure SQL SLAs. Read-only.
+	BackupType          BackupType `json:"backupType"`
 	BackupLocationSpecs []struct {
 		ArchivalGroup struct {
 			ID string `json:"id"`


### PR DESCRIPTION
## Summary

Adds Azure SQL V1/V2 SLA support to the global SLA domain types, consumed by the Terraform provider.

- Add `AzureSQLLtrConfig` (weekly / monthly / yearly long-term retention) plus the `AzureSQLLtrRetention`, `AzureSQLYearlyLtrRetention`, and `AzureSQLLtrRetentionUnit` types.
- Add `LTRConfig` to `AzureDBConfig` (Azure SQL Database and Managed Instance object-specific configs). A V1 (Azure-managed) SLA carries it; a V2 (Rubrik-managed) SLA leaves it `nil` and uses the existing SLA-level backup location specs.
- Add a read-only `BackupType` field (`NATIVE` for V1, `RUBRIK` for V2) to the global SLA domain reply.
- Select `ltrConfig` and `backupType` in the global SLA reply fragment and regenerate `queries.go`.

No changes to the create/update mutations are required — the new input fields flow through the existing object-specific configs input, and backup locations reuse the existing top-level backup location specs.

## Testing

- `go build ./...`, `go vet ./...`, `gofmt`, and `go test ./pkg/polaris/graphql/sla/...` pass.
- `go generate ./...` produces no diff.
- Exercised end-to-end through the Terraform provider against a live RSC tenant (create / read / update / delete of V1, V2, and combined Database + Managed Instance SLAs).
