### PR TITLE
Add test for OracleConfig retain-archive-logs-indefinitely sentinel

### DIFF
--- a/pkg/polaris/graphql/sla/sla_domain_test.go
+++ b/pkg/polaris/graphql/sla/sla_domain_test.go
@@ -78,6 +78,16 @@ func TestObjectSpecificConfigsOmitZeroRetention(t *testing.T) {
 			mustNotHave: []string{`"hostLogRetention"`, `"unit":""`},
 		},
 		{
+			name: "OracleConfig with retain-archive-logs-indefinitely sentinel (-2)",
+			value: OracleConfig{
+				Frequency:        RetentionDuration{Duration: 15, Unit: Minute},
+				LogRetention:     RetentionDuration{Duration: 14, Unit: Days},
+				HostLogRetention: RetentionDuration{Duration: -2, Unit: Minute},
+			},
+			mustHave:    []string{`"hostLogRetention"`, `"duration":-2`},
+			mustNotHave: []string{`"unit":""`},
+		},
+		{
 			name:        "SapHanaStorageSnapshotConfig empty",
 			value:       SapHanaStorageSnapshotConfig{},
 			mustNotHave: []string{`"frequency"`, `"retention"`, `"unit":""`},


### PR DESCRIPTION
Adds a test case to `TestObjectSpecificConfigsOmitZeroRetention` verifying that `RetentionDuration{Duration: -2}` is not omitted from JSON output. The `-2` sentinel maps to CDM's 'retain all archive logs indefinitely' behaviour.