### PR TITLE
Add CNP_AZURE_SQL_SLA_REVAMP feature flag constant

### DIFF
--- a/pkg/polaris/graphql/core/feature_flag.go
+++ b/pkg/polaris/graphql/core/feature_flag.go
@@ -35,6 +35,7 @@ type FeatureFlagName string
 const (
 	FeatureFlagAWSManualRoleChaining           FeatureFlagName = "REL_ENABLE_AWS_MANUAL_ROLE_CHAINING"
 	FeatureFlagAzureSQLDBCopyBackup            FeatureFlagName = "CNP_AZURE_SQL_DB_COPY_BACKUP"
+	FeatureFlagAzureSQLSLARevamp               FeatureFlagName = "CNP_AZURE_SQL_SLA_REVAMP"
 	FeatureFlagMultipleKeyValuePairsInTagRules FeatureFlagName = "CNP_MULTIPLE_KEY_VALUE_PAIRS_IN_TAG_RULES_ENABLED"
 )
 


### PR DESCRIPTION
## Summary

Adds a `FeatureFlagAzureSQLSLARevamp` constant for the `CNP_AZURE_SQL_SLA_REVAMP` feature flag, so callers can reference it by name instead of a raw string.

Requested during review of [terraform-provider-rubrik#42](https://github.com/rubrikinc/terraform-provider-rubrik/pull/42).

## Testing

`go build ./...`, `go vet ./...`, `gofmt`, and `go test ./pkg/polaris/graphql/core/...` pass.