### PR TITLE
Add AZURE_DEVOPS_PROTECTION_ENABLED feature flag constant

### DIFF
--- a/pkg/polaris/graphql/core/feature_flag.go
+++ b/pkg/polaris/graphql/core/feature_flag.go
@@ -34,6 +34,7 @@ type FeatureFlagName string
 
 const (
 	FeatureFlagAWSManualRoleChaining           FeatureFlagName = "REL_ENABLE_AWS_MANUAL_ROLE_CHAINING"
+	FeatureFlagAzureDevOpsProtection           FeatureFlagName = "AZURE_DEVOPS_PROTECTION_ENABLED"
 	FeatureFlagAzureSQLDBCopyBackup            FeatureFlagName = "CNP_AZURE_SQL_DB_COPY_BACKUP"
 	FeatureFlagAzureSQLSLARevamp               FeatureFlagName = "CNP_AZURE_SQL_SLA_REVAMP"
 	FeatureFlagMultipleKeyValuePairsInTagRules FeatureFlagName = "CNP_MULTIPLE_KEY_VALUE_PAIRS_IN_TAG_RULES_ENABLED"


### PR DESCRIPTION
# Description

Adds the `AZURE_DEVOPS_PROTECTION_ENABLED` feature flag constant (`FeatureFlagAzureDevOpsProtection`) to the `core` package so callers can reference the Azure DevOps protection flag by name instead of a raw string.

## Related Issue

None.

## Motivation and Context

Part of the ongoing Azure DevOps SDK support work. Consumers need a named constant to query this flag via the existing `FeatureFlag`/`FeatureFlags` API rather than hardcoding the string.

## How Has This Been Tested?

`go build ./...` passes. This is a trivial constant addition with no behavior change, so no new tests were added.

## Screenshots (if appropriate):

## Types of changes

What types of changes does your code introduce? Put an `x` in all the boxes that apply:
- [ ] Bug fix (non-breaking change which fixes an issue)
- [x] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)
- [ ] Other (please describe in the Description above)

## Checklist:

Go over all the following points, and put an `x` in all the boxes that apply. If you're unsure about any of these, don't hesitate to ask. We're here to help!
- [x] My code follows the code style of this project.
- [ ] My change requires a change to the documentation.
- [ ] I have updated the documentation accordingly.
- [ ] I have updated the CHANGELOG file accordingly for the version that this merge modifies.
- [ ] I have added tests to cover my changes.
- [ ] All new and existing tests passed.
