### PR TITLE
Add AzureSqlManagedInstanceServer inventory object type

### DIFF
--- a/pkg/polaris/graphql/hierarchy/hierarchy.go
+++ b/pkg/polaris/graphql/hierarchy/hierarchy.go
@@ -32,6 +32,7 @@ import (
 
 	"github.com/google/uuid"
 	"github.com/rubrikinc/rubrik-polaris-sdk-for-go/pkg/polaris/graphql"
+	azureregions "github.com/rubrikinc/rubrik-polaris-sdk-for-go/pkg/polaris/graphql/regions/azure"
 	"github.com/rubrikinc/rubrik-polaris-sdk-for-go/pkg/polaris/log"
 )
 
@@ -183,7 +184,7 @@ type Feature struct {
 // InventoryObject is a constraint for types that can be returned from the
 // inventory root query.
 type InventoryObject interface {
-	AWSNativeAccount | AWSNativeEC2Instance | AWSNativeEBSVolume | AWSNativeRDSInstance | AzureNativeSubscription | AzureNativeVirtualMachine | AzureDevOpsOrganization | AzureDevOpsProject | AzureDevOpsRepository | GitHubOrganization | GitHubRepository
+	AWSNativeAccount | AWSNativeEC2Instance | AWSNativeEBSVolume | AWSNativeRDSInstance | AzureNativeSubscription | AzureNativeVirtualMachine | AzureDevOpsOrganization | AzureDevOpsProject | AzureDevOpsRepository | AzureSQLManagedInstanceServer | GitHubOrganization | GitHubRepository
 	// typeFilter returns the object type filter to use for the inventory root
 	// query. It corresponds to values in the GraphQL Enum HierarchyObjectTypeEnum.
 	typeFilter() ObjectType
@@ -313,6 +314,41 @@ type AzureNativeVirtualMachine struct {
 // from the Go type name (AzureNativeVirtualMachine).
 func (AzureNativeVirtualMachine) typeFilter() ObjectType {
 	return "AzureNativeVm"
+}
+
+// AzureSubscriptionDetails holds the parent Azure subscription details returned
+// for inventory objects that expose them, such as SQL Managed Instance servers.
+type AzureSubscriptionDetails struct {
+	// ID is the native subscription FID.
+	ID   uuid.UUID `json:"id"`
+	Name string    `json:"name"`
+	// CloudAccountID is the RSC cloud account ID of the subscription. This is
+	// the value exposed as subscription_id elsewhere in RSC.
+	CloudAccountID uuid.UUID `json:"accountConnectionId"`
+	TenantID       uuid.UUID `json:"tenantId"`
+	// Cloud is the Azure cloud, e.g. AZUREPUBLICCLOUD. It mirrors the azure.Cloud
+	// values but is typed as a string here because importing the graphql/azure
+	// package would create an import cycle (azure -> core -> hierarchy).
+	Cloud       string `json:"cloudType"`
+	Status      string `json:"status"`
+	RegionSpecs []struct {
+		Region azureregions.NativeRegionEnum `json:"region"`
+	} `json:"regionSpecs"`
+}
+
+// AzureSQLManagedInstanceServer represents an Azure SQL Managed Instance server
+// from the inventory root. In addition to the common object fields it exposes
+// the parent subscription details, so callers can filter servers by
+// subscription client-side — the inventory query has no subscription filter.
+type AzureSQLManagedInstanceServer struct {
+	Object
+	ResourceGroup struct {
+		Subscription AzureSubscriptionDetails `json:"azureSubscriptionDetails"`
+	} `json:"azureResourceGroupDetails"`
+}
+
+func (AzureSQLManagedInstanceServer) typeFilter() ObjectType {
+	return "AzureSqlManagedInstanceServer"
 }
 
 // Filter represents a GraphQL Filter input for inventory queries.

--- a/pkg/polaris/graphql/hierarchy/hierarchy_test.go
+++ b/pkg/polaris/graphql/hierarchy/hierarchy_test.go
@@ -1,0 +1,152 @@
+// Copyright 2026 Rubrik, Inc.
+//
+// Permission is hereby granted, free of charge, to any person obtaining a copy
+// of this software and associated documentation files (the "Software"), to
+// deal in the Software without restriction, including without limitation the
+// rights to use, copy, modify, merge, publish, distribute, sublicense, and/or
+// sell copies of the Software, and to permit persons to whom the Software is
+// furnished to do so, subject to the following conditions:
+//
+// The above copyright notice and this permission notice shall be included in
+// all copies or substantial portions of the Software.
+//
+// THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+// IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+// FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+// AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+// LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING
+// FROM, OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER
+// DEALINGS IN THE SOFTWARE.
+
+package hierarchy
+
+import (
+	"context"
+	"encoding/json"
+	"io"
+	"net/http"
+	"net/http/httptest"
+	"testing"
+
+	"github.com/google/uuid"
+	"github.com/rubrikinc/rubrik-polaris-sdk-for-go/internal/assert"
+	"github.com/rubrikinc/rubrik-polaris-sdk-for-go/internal/handler"
+	"github.com/rubrikinc/rubrik-polaris-sdk-for-go/pkg/polaris/graphql"
+	azureregions "github.com/rubrikinc/rubrik-polaris-sdk-for-go/pkg/polaris/graphql/regions/azure"
+)
+
+// TestObjectsByName verifies that ObjectsByName sets the NAME_EXACT_MATCH filter
+// on the inventory query and unmarshals the returned nodes.
+func TestObjectsByName(t *testing.T) {
+	ctx, cancel := context.WithCancelCause(context.Background())
+	defer assert.Context(t, ctx, cancel)
+
+	const response = `{
+		"data": {
+			"result": {
+				"descendantConnection": {
+					"count": 1,
+					"nodes": [
+						{
+							"id": "11111111-1111-1111-1111-111111111111",
+							"name": "example-vm",
+							"objectType": "AzureNativeVm"
+						}
+					],
+					"pageInfo": {"endCursor": "", "hasNextPage": false}
+				}
+			}
+		}
+	}`
+
+	var gotFilter []Filter
+	srv := httptest.NewServer(handler.GraphQL(func(w http.ResponseWriter, req *http.Request) {
+		body, err := io.ReadAll(req.Body)
+		if err != nil {
+			t.Fatalf("read request body: %v", err)
+		}
+		var decoded struct {
+			Variables struct {
+				Filter []Filter `json:"filter"`
+			} `json:"variables"`
+		}
+		if err := json.Unmarshal(body, &decoded); err != nil {
+			t.Fatalf("unmarshal request body: %v", err)
+		}
+		gotFilter = decoded.Variables.Filter
+		io.WriteString(w, response)
+	}))
+	defer srv.Close()
+
+	objects, err := ObjectsByName[AzureNativeVirtualMachine](ctx, Wrap(graphql.NewTestClient(srv)), "example-vm", WorkloadAllSubHierarchyType)
+	if err != nil {
+		t.Fatalf("ObjectsByName failed: %v", err)
+	}
+
+	if len(gotFilter) != 1 || gotFilter[0].Field != "NAME_EXACT_MATCH" ||
+		len(gotFilter[0].Texts) != 1 || gotFilter[0].Texts[0] != "example-vm" {
+		t.Errorf("filter: got %+v, want NAME_EXACT_MATCH=[example-vm]", gotFilter)
+	}
+
+	if len(objects) != 1 {
+		t.Fatalf("got %d objects, want 1", len(objects))
+	}
+	if objects[0].ID != uuid.MustParse("11111111-1111-1111-1111-111111111111") {
+		t.Errorf("id: got %q", objects[0].ID)
+	}
+	if objects[0].Name != "example-vm" {
+		t.Errorf("name: got %q", objects[0].Name)
+	}
+}
+
+// TestAzureSQLManagedInstanceServer verifies the type's inventory type filter
+// and that an API response unmarshals into the type, including the parent
+// subscription details.
+func TestAzureSQLManagedInstanceServer(t *testing.T) {
+	// InventoryObject is a constraint interface, so it can't be used as a
+	// variable type; call typeFilter directly on the value instead.
+	if typeFilter := (AzureSQLManagedInstanceServer{}).typeFilter(); typeFilter != "AzureSqlManagedInstanceServer" {
+		t.Fatalf("wrong type filter: %s", typeFilter)
+	}
+
+	const res = `{
+		"id": "11111111-1111-1111-1111-111111111111",
+		"name": "example-sql-mi",
+		"objectType": "AzureSqlManagedInstanceServer",
+		"azureResourceGroupDetails": {
+			"azureSubscriptionDetails": {
+				"id": "22222222-2222-2222-2222-222222222222",
+				"name": "example-subscription",
+				"accountConnectionId": "33333333-3333-3333-3333-333333333333",
+				"tenantId": "44444444-4444-4444-4444-444444444444",
+				"cloudType": "AZUREPUBLICCLOUD",
+				"status": "REFRESHED",
+				"regionSpecs": [{"region": "EASTUS2"}]
+			}
+		}
+	}`
+
+	var obj AzureSQLManagedInstanceServer
+	if err := json.Unmarshal([]byte(res), &obj); err != nil {
+		t.Fatal(err)
+	}
+
+	if obj.Name != "example-sql-mi" {
+		t.Errorf("name: got %q", obj.Name)
+	}
+	if obj.ObjectType != "AzureSqlManagedInstanceServer" {
+		t.Errorf("objectType: got %q", obj.ObjectType)
+	}
+
+	sub := obj.ResourceGroup.Subscription
+	if sub.CloudAccountID != uuid.MustParse("33333333-3333-3333-3333-333333333333") {
+		t.Errorf("subscription cloud account ID: got %q", sub.CloudAccountID)
+	}
+	if sub.Cloud != "AZUREPUBLICCLOUD" {
+		t.Errorf("subscription cloud: got %q, want %q", sub.Cloud, "AZUREPUBLICCLOUD")
+	}
+	if len(sub.RegionSpecs) != 1 ||
+		sub.RegionSpecs[0].Region.Region != azureregions.RegionFromNativeRegionEnum("EASTUS2") {
+		t.Errorf("region specs: got %+v", sub.RegionSpecs)
+	}
+}

--- a/pkg/polaris/graphql/hierarchy/queries.go
+++ b/pkg/polaris/graphql/hierarchy/queries.go
@@ -80,6 +80,21 @@ var hierarchyObjectQuery = `query SdkGolangHierarchyObject($fid: UUID!, $workloa
         ... on GithubRepository {
             orgId
         }
+        ... on AzureSqlManagedInstanceServer {
+            azureResourceGroupDetails {
+                azureSubscriptionDetails {
+                    id
+                    name
+                    accountConnectionId
+                    tenantId
+                    cloudType
+                    status
+                    regionSpecs {
+                        region
+                    }
+                }
+            }
+        }
         configuredSlaDomain {
             ... on ClusterSlaDomain {
                 id
@@ -137,6 +152,21 @@ var inventoryRootQuery = `query SdkGolangInventoryRoot($after: String, $filter: 
                 }
                 ... on GithubRepository {
                     orgId
+                }
+                ... on AzureSqlManagedInstanceServer {
+                    azureResourceGroupDetails {
+                        azureSubscriptionDetails {
+                            id
+                            name
+                            accountConnectionId
+                            tenantId
+                            cloudType
+                            status
+                            regionSpecs {
+                                region
+                            }
+                        }
+                    }
                 }
             }
             count

--- a/pkg/polaris/graphql/hierarchy/queries/hierarchy_object.graphql
+++ b/pkg/polaris/graphql/hierarchy/queries/hierarchy_object.graphql
@@ -29,6 +29,21 @@ query RubrikPolarisSDKRequest($fid: UUID!, $workloadHierarchy: WorkloadLevelHier
         ... on GithubRepository {
             orgId
         }
+        ... on AzureSqlManagedInstanceServer {
+            azureResourceGroupDetails {
+                azureSubscriptionDetails {
+                    id
+                    name
+                    accountConnectionId
+                    tenantId
+                    cloudType
+                    status
+                    regionSpecs {
+                        region
+                    }
+                }
+            }
+        }
         configuredSlaDomain {
             ... on ClusterSlaDomain {
                 id

--- a/pkg/polaris/graphql/hierarchy/queries/inventory_root.graphql
+++ b/pkg/polaris/graphql/hierarchy/queries/inventory_root.graphql
@@ -32,6 +32,21 @@ query RubrikPolarisSDKRequest($after: String, $filter: [Filter!], $first: Int, $
                 ... on GithubRepository {
                     orgId
                 }
+                ... on AzureSqlManagedInstanceServer {
+                    azureResourceGroupDetails {
+                        azureSubscriptionDetails {
+                            id
+                            name
+                            accountConnectionId
+                            tenantId
+                            cloudType
+                            status
+                            regionSpecs {
+                                region
+                            }
+                        }
+                    }
+                }
             }
             count
             pageInfo {


### PR DESCRIPTION
## Summary

Extend the inventory-root and `hierarchyObject` queries to return Azure SQL Managed Instance servers, and add `AzureSqlManagedInstanceServer` as an `InventoryObject` type so it can be looked up with `ObjectsByName` / `ObjectsByType` like other inventory objects (e.g. Azure VMs).

This is the first slice of Azure SQL MI ("BAK") support: it lets callers resolve a SQL MI server to its RSC object ID by name, which the `terraform-provider-rubrik` `rubrik_object` data source will consume (that provider change ships separately).

## Changes

- `queries/inventory_root.graphql`, `queries/hierarchy_object.graphql` — add a `... on AzureSqlManagedInstanceServer` fragment pulling the parent `azureSubscriptionDetails`.
- `hierarchy.go` — new `AzureSqlManagedInstanceServer` and `AzureSubscriptionDetails` types; register the former in the `InventoryObject` union with `typeFilter()` = `AzureSqlManagedInstanceServer`.
- `hierarchy_test.go` — mock-GraphQL unit test.

## Notes

The inventory query has no subscription filter, so callers filter by subscription client-side. The node's `accountConnectionId` is the RSC cloud account ID, so no native-FID translation is required.

## Testing

- **Unit:** mock-GraphQL test asserts the type filter and exact-name filter sent, and parses a server node including its subscription details.
- **Live (dev RSC, identifiers omitted):** `ObjectsByType` with the active filters returns the expected active servers, each carrying the parent subscription; `ObjectsByName` resolves an exact name to a single server.