### PR TITLE
Fix AzureSubscriptionDetails tenant field type

### DIFF
--- a/pkg/polaris/graphql/hierarchy/hierarchy.go
+++ b/pkg/polaris/graphql/hierarchy/hierarchy.go
@@ -325,7 +325,10 @@ type AzureSubscriptionDetails struct {
 	// CloudAccountID is the RSC cloud account ID of the subscription. This is
 	// the value exposed as subscription_id elsewhere in RSC.
 	CloudAccountID uuid.UUID `json:"accountConnectionId"`
-	TenantID       uuid.UUID `json:"tenantId"`
+	// TenantDomain is the Azure tenant domain, e.g. example.onmicrosoft.com.
+	// RSC returns it in a field named tenantId even though it is a domain and
+	// not a UUID.
+	TenantDomain string `json:"tenantId"`
 	// Cloud is the Azure cloud, e.g. AZUREPUBLICCLOUD. It mirrors the azure.Cloud
 	// values but is typed as a string here because importing the graphql/azure
 	// package would create an import cycle (azure -> core -> hierarchy).

--- a/pkg/polaris/graphql/hierarchy/hierarchy_test.go
+++ b/pkg/polaris/graphql/hierarchy/hierarchy_test.go
@@ -118,10 +118,10 @@ func TestAzureSQLManagedInstanceServer(t *testing.T) {
 				"id": "22222222-2222-2222-2222-222222222222",
 				"name": "example-subscription",
 				"accountConnectionId": "33333333-3333-3333-3333-333333333333",
-				"tenantId": "44444444-4444-4444-4444-444444444444",
+				"tenantId": "example.onmicrosoft.com",
 				"cloudType": "AZUREPUBLICCLOUD",
 				"status": "REFRESHED",
-				"regionSpecs": [{"region": "EASTUS2"}]
+				"regionSpecs": [{"region": "EAST_US2"}]
 			}
 		}
 	}`
@@ -142,11 +142,17 @@ func TestAzureSQLManagedInstanceServer(t *testing.T) {
 	if sub.CloudAccountID != uuid.MustParse("33333333-3333-3333-3333-333333333333") {
 		t.Errorf("subscription cloud account ID: got %q", sub.CloudAccountID)
 	}
+	// RSC returns the tenant domain, not a UUID, in the tenantId field.
+	if sub.TenantDomain != "example.onmicrosoft.com" {
+		t.Errorf("subscription tenant domain: got %q", sub.TenantDomain)
+	}
 	if sub.Cloud != "AZUREPUBLICCLOUD" {
 		t.Errorf("subscription cloud: got %q, want %q", sub.Cloud, "AZUREPUBLICCLOUD")
 	}
-	if len(sub.RegionSpecs) != 1 ||
-		sub.RegionSpecs[0].Region.Region != azureregions.RegionFromNativeRegionEnum("EASTUS2") {
-		t.Errorf("region specs: got %+v", sub.RegionSpecs)
+	// Compare against the region constant rather than round-tripping the same
+	// string through RegionFromNativeRegionEnum, which would pass vacuously if
+	// both sides resolved to RegionUnknown.
+	if len(sub.RegionSpecs) != 1 || sub.RegionSpecs[0].Region.Region != azureregions.RegionEastUS2 {
+		t.Errorf("region specs: got %+v, want [EAST_US2]", sub.RegionSpecs)
 	}
 }


### PR DESCRIPTION
## Summary

Follow-up fix for #399. `azureSubscriptionDetails.tenantId` carries the Azure tenant **domain**, not a UUID, so `AzureSubscriptionDetails.TenantID uuid.UUID` fails to unmarshal against a real RSC instance:

```
failed to unmarshal inventoryRoot: invalid UUID length: 27
```

Every `ObjectsByName` / `ObjectsByType` lookup for `AzureSqlManagedInstanceServer` currently fails on main because of this.

## Changes

- `hierarchy.go` — rename `TenantID uuid.UUID` to `TenantDomain string`, matching the `TenantDomain` / `tenantDomainName` vocabulary already used in the `graphql/azure` package. Comment records that RSC returns a domain in a field named `tenantId`.
- `hierarchy_test.go` — replace the hand-written fixture values with the shape RSC actually returns, and assert on the tenant domain.

## Why the test did not catch it

Two independent fixture problems, both fixed here:

1. `tenantId` was a fabricated UUID (`44444444-...`), so the `uuid.UUID` field parsed fine in the test and only failed against real data.
2. `regionSpecs[].region` was `"EASTUS2"` — the *common* region enum spelling, not the *native* one (`"EAST_US2"`). `RegionFromNativeRegionEnum("EASTUS2")` returns `RegionUnknown`, and the assertion compared it against a value that also resolved to `RegionUnknown`, so the region check passed vacuously. The fixture now uses the native spelling and the assertion compares against the `RegionEastUS2` constant directly.

## Testing

- **Unit:** with main's `uuid.UUID` field and the corrected fixture, the test fails with `invalid UUID length: 23`; with the fix it passes. Verified both directions rather than assuming.
- **Live (dev RSC, identifiers omitted):** the inventory query returns all four SQL Managed Instance servers, each with its parent subscription, tenant domain and region parsed correctly. Also verified end to end through the `rubrik_object` / `polaris_object` Terraform data sources, including subscription-scoped lookups and a negative case.