### PR TITLE
Add Azure SQL Managed Instance backup setup to the azure API

### DIFF
--- a/pkg/polaris/azure/sql_server.go
+++ b/pkg/polaris/azure/sql_server.go
@@ -29,7 +29,6 @@ import (
 	"github.com/google/uuid"
 	gqlazure "github.com/rubrikinc/rubrik-polaris-sdk-for-go/pkg/polaris/graphql/azure"
 	"github.com/rubrikinc/rubrik-polaris-sdk-for-go/pkg/polaris/graphql/core"
-	"github.com/rubrikinc/rubrik-polaris-sdk-for-go/pkg/polaris/graphql/core/secret"
 	"github.com/rubrikinc/rubrik-polaris-sdk-for-go/pkg/polaris/graphql/hierarchy"
 	"github.com/rubrikinc/rubrik-polaris-sdk-for-go/pkg/polaris/log"
 )
@@ -42,16 +41,19 @@ const defaultSQLServerBackupSetupPollInterval = 10 * time.Second
 // Managed Instance servers using SQL Server authentication, and blocks until
 // every task chain started has finished.
 //
-// The login and password are the credentials of a SQL Server user with
-// permission to create the user RSC uses to perform backups. They are sent to
-// RSC but never stored by the SDK. Microsoft Entra ID authentication is not
-// supported yet.
+// The credentials are those of a SQL Server user with permission to create the
+// user RSC uses to perform backups. They are sent to RSC but never stored by
+// the SDK. Microsoft Entra ID authentication is not supported yet.
 //
 // A pollInterval of zero uses a default interval. Note that the credentials are
 // only validated against the managed instance once the task chain runs, so
 // invalid credentials surface as a failed task chain rather than as an error
 // from the initial request.
-func (a API) SetupSQLManagedInstanceBackup(ctx context.Context, serverIDs []uuid.UUID, login string, password secret.String, pollInterval time.Duration) error {
+//
+// Servers are set up independently of each other, so a failure for one server
+// does not stop the others. All failures are collected and returned together as
+// a joined error.
+func (a API) SetupSQLManagedInstanceBackup(ctx context.Context, serverIDs []uuid.UUID, credentials gqlazure.LoginCredentials, pollInterval time.Duration) error {
 	a.log.Print(log.Trace)
 
 	if len(serverIDs) == 0 {
@@ -61,34 +63,42 @@ func (a API) SetupSQLManagedInstanceBackup(ctx context.Context, serverIDs []uuid
 		pollInterval = defaultSQLServerBackupSetupPollInterval
 	}
 
-	status, err := gqlazure.Wrap(a.client).SetupCloudNativeSQLServerBackup(ctx, serverIDs, nil,
-		gqlazure.LoginCredentials{Login: login, Password: password}, gqlazure.SQLAuthentication)
+	status, err := gqlazure.Wrap(a.client).SetupCloudNativeSQLServerBackup(ctx, serverIDs, nil, credentials,
+		gqlazure.SQLAuthentication)
 	if err != nil {
 		return fmt.Errorf("failed to set up SQL Managed Instance backup: %s", err)
 	}
 
-	// Objects which fail pre-validation never get a task chain, so they must be
-	// reported separately from the task chain results below.
+	// Objects which fail pre-validation never get a task chain, so they are
+	// reported separately from the task chain results below. Note that they are
+	// only collected here, not returned yet: task chains may already be running
+	// for the other servers and those must still be waited for.
+	var errs []error
 	for _, e := range status.Errors {
-		return fmt.Errorf("failed to set up backup for SQL Managed Instance server %s: %s", e.ObjectID, e.Error)
+		errs = append(errs, fmt.Errorf("failed to set up backup for SQL Managed Instance server %s: %s",
+			e.ObjectID, e.Error))
 	}
-	if len(status.JobIDs) == 0 {
+	if len(status.JobIDs) == 0 && len(errs) == 0 {
 		return errors.New("failed to set up SQL Managed Instance backup: no jobs were started")
 	}
 
+	// Wait for every task chain, recording rather than returning failures, so
+	// that a failure for one server does not leave the remaining task chains
+	// running unwaited.
 	coreAPI := core.Wrap(a.client)
 	for _, job := range status.JobIDs {
 		state, err := coreAPI.WaitForTaskChain(ctx, job.JobID, pollInterval)
-		if err != nil {
-			return fmt.Errorf("failed to wait for backup setup of SQL Managed Instance server %s: %s", job.ObjectID, err)
-		}
-		if state != core.TaskChainSucceeded {
-			return fmt.Errorf("backup setup of SQL Managed Instance server %s ended in state %s, verify that the "+
-				"credentials are valid for the managed instance", job.ObjectID, state)
+		switch {
+		case err != nil:
+			errs = append(errs, fmt.Errorf("failed to wait for backup setup of SQL Managed Instance server %s: %s",
+				job.ObjectID, err))
+		case state != core.TaskChainSucceeded:
+			errs = append(errs, fmt.Errorf("backup setup of SQL Managed Instance server %s ended in state %s, "+
+				"verify that the credentials are valid for the managed instance", job.ObjectID, state))
 		}
 	}
 
-	return nil
+	return errors.Join(errs...)
 }
 
 // ClearSQLManagedInstanceBackupCredentials clears the backup credentials of the

--- a/pkg/polaris/azure/sql_server.go
+++ b/pkg/polaris/azure/sql_server.go
@@ -74,12 +74,25 @@ func (a API) SetupSQLManagedInstanceBackup(ctx context.Context, serverIDs []uuid
 	// only collected here, not returned yet: task chains may already be running
 	// for the other servers and those must still be waited for.
 	var errs []error
+	acknowledged := make(map[uuid.UUID]struct{}, len(status.JobIDs)+len(status.Errors))
 	for _, e := range status.Errors {
+		acknowledged[e.ObjectID] = struct{}{}
 		errs = append(errs, fmt.Errorf("failed to set up backup for SQL Managed Instance server %s: %s",
 			e.ObjectID, e.Error))
 	}
-	if len(status.JobIDs) == 0 && len(errs) == 0 {
-		return errors.New("failed to set up SQL Managed Instance backup: no jobs were started")
+	for _, job := range status.JobIDs {
+		acknowledged[job.ObjectID] = struct{}{}
+	}
+
+	// RSC acknowledges each requested server with either a task chain or a
+	// pre-validation error. A server in neither list was silently dropped, so
+	// report it instead of returning success for a server never set up. This
+	// also covers RSC returning nothing at all, in which case every requested
+	// server is reported.
+	for _, serverID := range serverIDs {
+		if _, ok := acknowledged[serverID]; !ok {
+			errs = append(errs, fmt.Errorf("no job was started for SQL Managed Instance server %s", serverID))
+		}
 	}
 
 	// Wait for every task chain, recording rather than returning failures, so
@@ -87,6 +100,15 @@ func (a API) SetupSQLManagedInstanceBackup(ctx context.Context, serverIDs []uuid
 	// running unwaited.
 	coreAPI := core.Wrap(a.client)
 	for _, job := range status.JobIDs {
+		// Once the context is done, waiting for the remaining task chains only
+		// produces one duplicate failure per server, so stop and report the
+		// cause once. Wrapped with %w, unlike the errors below, so that callers
+		// can tell cancellation apart from a genuine setup failure.
+		if err := ctx.Err(); err != nil {
+			errs = append(errs, fmt.Errorf("interrupted while waiting for SQL Managed Instance backup setup: %w", err))
+			break
+		}
+
 		state, err := coreAPI.WaitForTaskChain(ctx, job.JobID, pollInterval)
 		switch {
 		case err != nil:

--- a/pkg/polaris/azure/sql_server.go
+++ b/pkg/polaris/azure/sql_server.go
@@ -1,0 +1,113 @@
+// Copyright 2026 Rubrik, Inc.
+//
+// Permission is hereby granted, free of charge, to any person obtaining a copy
+// of this software and associated documentation files (the "Software"), to
+// deal in the Software without restriction, including without limitation the
+// rights to use, copy, modify, merge, publish, distribute, sublicense, and/or
+// sell copies of the Software, and to permit persons to whom the Software is
+// furnished to do so, subject to the following conditions:
+//
+// The above copyright notice and this permission notice shall be included in
+// all copies or substantial portions of the Software.
+//
+// THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+// IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+// FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+// AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+// LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING
+// FROM, OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER
+// DEALINGS IN THE SOFTWARE.
+
+package azure
+
+import (
+	"context"
+	"errors"
+	"fmt"
+	"time"
+
+	"github.com/google/uuid"
+	gqlazure "github.com/rubrikinc/rubrik-polaris-sdk-for-go/pkg/polaris/graphql/azure"
+	"github.com/rubrikinc/rubrik-polaris-sdk-for-go/pkg/polaris/graphql/core"
+	"github.com/rubrikinc/rubrik-polaris-sdk-for-go/pkg/polaris/graphql/core/secret"
+	"github.com/rubrikinc/rubrik-polaris-sdk-for-go/pkg/polaris/graphql/hierarchy"
+	"github.com/rubrikinc/rubrik-polaris-sdk-for-go/pkg/polaris/log"
+)
+
+// defaultSQLServerBackupSetupPollInterval is how often the backup setup task
+// chains are polled when no interval is specified.
+const defaultSQLServerBackupSetupPollInterval = 10 * time.Second
+
+// SetupSQLManagedInstanceBackup sets up backups for the specified Azure SQL
+// Managed Instance servers using SQL Server authentication, and blocks until
+// every task chain started has finished.
+//
+// The login and password are the credentials of a SQL Server user with
+// permission to create the user RSC uses to perform backups. They are sent to
+// RSC but never stored by the SDK. Microsoft Entra ID authentication is not
+// supported yet.
+//
+// A pollInterval of zero uses a default interval. Note that the credentials are
+// only validated against the managed instance once the task chain runs, so
+// invalid credentials surface as a failed task chain rather than as an error
+// from the initial request.
+func (a API) SetupSQLManagedInstanceBackup(ctx context.Context, serverIDs []uuid.UUID, login string, password secret.String, pollInterval time.Duration) error {
+	a.log.Print(log.Trace)
+
+	if len(serverIDs) == 0 {
+		return errors.New("at least one server ID is required")
+	}
+	if pollInterval <= 0 {
+		pollInterval = defaultSQLServerBackupSetupPollInterval
+	}
+
+	status, err := gqlazure.Wrap(a.client).SetupCloudNativeSQLServerBackup(ctx, serverIDs, nil,
+		gqlazure.LoginCredentials{Login: login, Password: password}, gqlazure.SQLAuthentication)
+	if err != nil {
+		return fmt.Errorf("failed to set up SQL Managed Instance backup: %s", err)
+	}
+
+	// Objects which fail pre-validation never get a task chain, so they must be
+	// reported separately from the task chain results below.
+	for _, e := range status.Errors {
+		return fmt.Errorf("failed to set up backup for SQL Managed Instance server %s: %s", e.ObjectID, e.Error)
+	}
+	if len(status.JobIDs) == 0 {
+		return errors.New("failed to set up SQL Managed Instance backup: no jobs were started")
+	}
+
+	coreAPI := core.Wrap(a.client)
+	for _, job := range status.JobIDs {
+		state, err := coreAPI.WaitForTaskChain(ctx, job.JobID, pollInterval)
+		if err != nil {
+			return fmt.Errorf("failed to wait for backup setup of SQL Managed Instance server %s: %s", job.ObjectID, err)
+		}
+		if state != core.TaskChainSucceeded {
+			return fmt.Errorf("backup setup of SQL Managed Instance server %s ended in state %s, verify that the "+
+				"credentials are valid for the managed instance", job.ObjectID, state)
+		}
+	}
+
+	return nil
+}
+
+// ClearSQLManagedInstanceBackupCredentials clears the backup credentials of the
+// specified Azure SQL Managed Instance servers.
+func (a API) ClearSQLManagedInstanceBackupCredentials(ctx context.Context, serverIDs []uuid.UUID) error {
+	a.log.Print(log.Trace)
+
+	if len(serverIDs) == 0 {
+		return errors.New("at least one server ID is required")
+	}
+
+	_, failedIDs, err := gqlazure.Wrap(a.client).ClearCloudNativeSQLServerBackupCredentials(ctx, serverIDs,
+		hierarchy.WorkloadAzureSQLMIDB)
+	if err != nil {
+		return fmt.Errorf("failed to clear SQL Managed Instance backup credentials: %s", err)
+	}
+	if len(failedIDs) > 0 {
+		return fmt.Errorf("failed to clear backup credentials for SQL Managed Instance servers: %v", failedIDs)
+	}
+
+	return nil
+}

--- a/pkg/polaris/azure/sql_server_test.go
+++ b/pkg/polaris/azure/sql_server_test.go
@@ -1,0 +1,297 @@
+// Copyright 2026 Rubrik, Inc.
+//
+// Permission is hereby granted, free of charge, to any person obtaining a copy
+// of this software and associated documentation files (the "Software"), to
+// deal in the Software without restriction, including without limitation the
+// rights to use, copy, modify, merge, publish, distribute, sublicense, and/or
+// sell copies of the Software, and to permit persons to whom the Software is
+// furnished to do so, subject to the following conditions:
+//
+// The above copyright notice and this permission notice shall be included in
+// all copies or substantial portions of the Software.
+//
+// THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+// IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+// FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+// AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+// LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING
+// FROM, OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER
+// DEALINGS IN THE SOFTWARE.
+
+package azure
+
+import (
+	"context"
+	"encoding/json"
+	"errors"
+	"io"
+	"net/http"
+	"net/http/httptest"
+	"strings"
+	"sync/atomic"
+	"testing"
+	"time"
+
+	"github.com/google/uuid"
+	"github.com/rubrikinc/rubrik-polaris-sdk-for-go/internal/assert"
+	"github.com/rubrikinc/rubrik-polaris-sdk-for-go/internal/handler"
+	"github.com/rubrikinc/rubrik-polaris-sdk-for-go/pkg/polaris/graphql"
+	gqlazure "github.com/rubrikinc/rubrik-polaris-sdk-for-go/pkg/polaris/graphql/azure"
+	"github.com/rubrikinc/rubrik-polaris-sdk-for-go/pkg/polaris/graphql/core"
+)
+
+// These tests cover the orchestration in SetupSQLManagedInstanceBackup: which
+// servers are reported as failed, which task chains are waited for, and how the
+// failures are aggregated. The two RSC calls involved, the setup mutation and
+// the task chain polling, are stubbed by a single handler which dispatches on
+// the query body.
+//
+// Unlike the graphql-layer tests, the responses here vary per test case rather
+// than being one recorded reply, so they are marshalled from Go values instead
+// of being rendered from a testdata fixture.
+
+var testCredentials = gqlazure.LoginCredentials{Login: "draper", Password: "s3cret"}
+
+// setupReply is the stubbed reply to the backup setup mutation. Job IDs are
+// generated per server, so the tests only name the servers.
+type setupReply struct {
+	// started lists the servers RSC accepts and starts a task chain for.
+	started []uuid.UUID
+	// preValidationFailed maps a server to the reason RSC rejected it before
+	// starting a task chain.
+	preValidationFailed map[uuid.UUID]string
+	// taskChainState is the state every started task chain reports.
+	taskChainState core.TaskChainState
+}
+
+// sqlServerHandler stubs the setup mutation and the task chain polling. It
+// returns the handler and a counter of task chain status polls, which the tests
+// use to tell "waited for" from "skipped".
+func sqlServerHandler(cancel context.CancelCauseFunc, reply setupReply, onPoll func()) (http.Handler, *atomic.Int64) {
+	var polls atomic.Int64
+
+	jobIDs := make(map[uuid.UUID]uuid.UUID, len(reply.started))
+	for _, serverID := range reply.started {
+		jobIDs[serverID] = uuid.New()
+	}
+
+	return handler.GraphQL(func(w http.ResponseWriter, req *http.Request) {
+		body, err := io.ReadAll(req.Body)
+		if err != nil {
+			cancel(err)
+			return
+		}
+
+		var payload struct {
+			Query string `json:"query"`
+		}
+		if err := json.Unmarshal(body, &payload); err != nil {
+			cancel(err)
+			return
+		}
+
+		var response any
+		switch {
+		case strings.Contains(payload.Query, "setupCloudNativeSqlServerBackup"):
+			type jobID struct {
+				JobID    uuid.UUID `json:"jobId"`
+				ObjectID uuid.UUID `json:"rubrikObjectId"`
+			}
+			type jobError struct {
+				Error    string    `json:"error"`
+				ObjectID uuid.UUID `json:"rubrikObjectId"`
+			}
+
+			jobs := []jobID{}
+			for _, serverID := range reply.started {
+				jobs = append(jobs, jobID{JobID: jobIDs[serverID], ObjectID: serverID})
+			}
+			jobErrors := []jobError{}
+			for serverID, msg := range reply.preValidationFailed {
+				jobErrors = append(jobErrors, jobError{Error: msg, ObjectID: serverID})
+			}
+
+			response = map[string]any{"data": map[string]any{"result": map[string]any{
+				"jobIds": jobs,
+				"errors": jobErrors,
+			}}}
+		case strings.Contains(payload.Query, "getKorgTaskchainStatus"):
+			polls.Add(1)
+			if onPoll != nil {
+				onPoll()
+			}
+			response = map[string]any{"data": map[string]any{"getKorgTaskchainStatus": map[string]any{
+				"taskchain": map[string]any{"id": 1, "state": reply.taskChainState},
+			}}}
+		default:
+			cancel(errors.New("unexpected query: " + payload.Query))
+			return
+		}
+
+		if err := json.NewEncoder(w).Encode(response); err != nil {
+			cancel(err)
+		}
+	}), &polls
+}
+
+// TestSetupSQLManagedInstanceBackup verifies that the happy path waits for every
+// task chain and reports success.
+func TestSetupSQLManagedInstanceBackup(t *testing.T) {
+	ctx, cancel := context.WithCancelCause(context.Background())
+	defer assert.Context(t, ctx, cancel)
+
+	serverIDs := []uuid.UUID{uuid.New(), uuid.New()}
+	h, polls := sqlServerHandler(cancel, setupReply{
+		started:        serverIDs,
+		taskChainState: core.TaskChainSucceeded,
+	}, nil)
+	srv := httptest.NewServer(h)
+	defer srv.Close()
+
+	err := WrapGQL(graphql.NewTestClient(srv)).SetupSQLManagedInstanceBackup(ctx, serverIDs, testCredentials,
+		time.Millisecond)
+	if err != nil {
+		t.Errorf("SetupSQLManagedInstanceBackup failed: %v", err)
+	}
+	if got := polls.Load(); got != 2 {
+		t.Errorf("task chain polls: got %d, want 2, one per server", got)
+	}
+}
+
+// TestSetupSQLManagedInstanceBackupUnacknowledgedServer verifies that a server
+// RSC returns in neither jobIds nor errors is reported rather than being
+// silently treated as successful.
+func TestSetupSQLManagedInstanceBackupUnacknowledgedServer(t *testing.T) {
+	ctx, cancel := context.WithCancelCause(context.Background())
+	defer assert.Context(t, ctx, cancel)
+
+	acknowledged, dropped1, dropped2 := uuid.New(), uuid.New(), uuid.New()
+	serverIDs := []uuid.UUID{acknowledged, dropped1, dropped2}
+
+	// RSC acknowledges one of the three servers, and its task chain succeeds.
+	h, _ := sqlServerHandler(cancel, setupReply{
+		started:        []uuid.UUID{acknowledged},
+		taskChainState: core.TaskChainSucceeded,
+	}, nil)
+	srv := httptest.NewServer(h)
+	defer srv.Close()
+
+	err := WrapGQL(graphql.NewTestClient(srv)).SetupSQLManagedInstanceBackup(ctx, serverIDs, testCredentials,
+		time.Millisecond)
+	if err == nil {
+		t.Fatal("expected SetupSQLManagedInstanceBackup to fail for the servers RSC did not acknowledge")
+	}
+	for _, serverID := range []uuid.UUID{dropped1, dropped2} {
+		if !strings.Contains(err.Error(), serverID.String()) {
+			t.Errorf("error does not mention dropped server %s: %v", serverID, err)
+		}
+	}
+	if strings.Contains(err.Error(), acknowledged.String()) {
+		t.Errorf("error mentions the server that succeeded %s: %v", acknowledged, err)
+	}
+}
+
+// TestSetupSQLManagedInstanceBackupNoServersAcknowledged verifies that an empty
+// reply reports every requested server rather than a single generic error.
+func TestSetupSQLManagedInstanceBackupNoServersAcknowledged(t *testing.T) {
+	ctx, cancel := context.WithCancelCause(context.Background())
+	defer assert.Context(t, ctx, cancel)
+
+	serverIDs := []uuid.UUID{uuid.New(), uuid.New()}
+	h, polls := sqlServerHandler(cancel, setupReply{}, nil)
+	srv := httptest.NewServer(h)
+	defer srv.Close()
+
+	err := WrapGQL(graphql.NewTestClient(srv)).SetupSQLManagedInstanceBackup(ctx, serverIDs, testCredentials,
+		time.Millisecond)
+	if err == nil {
+		t.Fatal("expected SetupSQLManagedInstanceBackup to fail when no jobs were started")
+	}
+	for _, serverID := range serverIDs {
+		if !strings.Contains(err.Error(), serverID.String()) {
+			t.Errorf("error does not mention server %s: %v", serverID, err)
+		}
+	}
+	if got := polls.Load(); got != 0 {
+		t.Errorf("task chain polls: got %d, want 0", got)
+	}
+}
+
+// TestSetupSQLManagedInstanceBackupPreValidationAndTaskChain verifies that a
+// pre-validation failure does not abandon the task chains already started for
+// the other servers, and that both failures are reported together.
+func TestSetupSQLManagedInstanceBackupPreValidationAndTaskChain(t *testing.T) {
+	ctx, cancel := context.WithCancelCause(context.Background())
+	defer assert.Context(t, ctx, cancel)
+
+	rejected, started := uuid.New(), uuid.New()
+	serverIDs := []uuid.UUID{rejected, started}
+
+	h, polls := sqlServerHandler(cancel, setupReply{
+		started:             []uuid.UUID{started},
+		preValidationFailed: map[uuid.UUID]string{rejected: "invalid credentials"},
+		taskChainState:      core.TaskChainFailed,
+	}, nil)
+	srv := httptest.NewServer(h)
+	defer srv.Close()
+
+	err := WrapGQL(graphql.NewTestClient(srv)).SetupSQLManagedInstanceBackup(ctx, serverIDs, testCredentials,
+		time.Millisecond)
+	if err == nil {
+		t.Fatal("expected SetupSQLManagedInstanceBackup to fail")
+	}
+
+	// The task chain must have been waited for despite the pre-validation
+	// failure, otherwise it would have been left running unwaited.
+	if got := polls.Load(); got == 0 {
+		t.Error("the started task chain was not waited for")
+	}
+	if !strings.Contains(err.Error(), "invalid credentials") {
+		t.Errorf("error does not report the pre-validation failure: %v", err)
+	}
+	if !strings.Contains(err.Error(), string(core.TaskChainFailed)) {
+		t.Errorf("error does not report the failed task chain: %v", err)
+	}
+	for _, serverID := range serverIDs {
+		if !strings.Contains(err.Error(), serverID.String()) {
+			t.Errorf("error does not mention server %s: %v", serverID, err)
+		}
+	}
+}
+
+// TestSetupSQLManagedInstanceBackupCancelled verifies that cancelling the
+// context stops the wait instead of producing one failure per remaining server,
+// and that the cause remains detectable with errors.Is.
+func TestSetupSQLManagedInstanceBackupCancelled(t *testing.T) {
+	ctx, cancel := context.WithCancel(context.Background())
+	defer cancel()
+
+	// The context is cancelled from the first task chain poll, leaving the
+	// remaining servers' task chains outstanding.
+	serverIDs := []uuid.UUID{uuid.New(), uuid.New(), uuid.New(), uuid.New(), uuid.New()}
+	h, polls := sqlServerHandler(func(error) {}, setupReply{
+		started:        serverIDs,
+		taskChainState: core.TaskChainRunning,
+	}, cancel)
+	srv := httptest.NewServer(h)
+	defer srv.Close()
+
+	err := WrapGQL(graphql.NewTestClient(srv)).SetupSQLManagedInstanceBackup(ctx, serverIDs, testCredentials,
+		time.Millisecond)
+	if err == nil {
+		t.Fatal("expected SetupSQLManagedInstanceBackup to fail after cancellation")
+	}
+	if !errors.Is(err, context.Canceled) {
+		t.Errorf("cancellation is not detectable with errors.Is: %v", err)
+	}
+
+	// One server's wait fails, then the loop stops. Without the check the
+	// remaining servers would each add a near-identical failure.
+	if got := len(strings.Split(err.Error(), "\n")); got >= len(serverIDs) {
+		t.Errorf("got %d errors for %d servers, want the wait to stop on cancellation: %v",
+			got, len(serverIDs), err)
+	}
+	if got := polls.Load(); got > int64(len(serverIDs)) {
+		t.Errorf("task chain polls: got %d, want the polling to stop on cancellation", got)
+	}
+}

--- a/pkg/polaris/graphql/azure/queries.go
+++ b/pkg/polaris/graphql/azure/queries.go
@@ -310,6 +310,17 @@ var azureNativeSubscriptionsWithFilterQuery = `query SdkGolangAzureNativeSubscri
     }
 }`
 
+// clearCloudNativeSqlServerBackupCredentials GraphQL query
+var clearCloudNativeSqlServerBackupCredentialsQuery = `mutation SdkGolangClearCloudNativeSqlServerBackupCredentials($objectIds: [UUID!]!, $workloadType: WorkloadLevelHierarchy!) {
+    result: clearCloudNativeSqlServerBackupCredentials(input: {
+        objectIds:    $objectIds,
+        workloadType: $workloadType
+    }) {
+        successObjectIds
+        failedObjectIds
+    }
+}`
+
 // deleteAzureCloudAccountWithoutOauth GraphQL query
 var deleteAzureCloudAccountWithoutOauthQuery = `mutation SdkGolangDeleteAzureCloudAccountWithoutOauth($subscriptionIds: [UUID!]!, $features: [CloudAccountFeature!]!) {
     result: deleteAzureCloudAccountWithoutOauth(input: {
@@ -354,6 +365,25 @@ var setRubrikCustomerAppForAzureDevopsQuery = `mutation SdkGolangSetRubrikCustom
     clientSecret:  $clientSecret,
     shouldReplace: $shouldReplace,
   })
+}`
+
+// setupCloudNativeSqlServerBackup GraphQL query
+var setupCloudNativeSqlServerBackupQuery = `mutation SdkGolangSetupCloudNativeSqlServerBackup($serverIds: [UUID!], $databaseIds: [UUID!], $adminCredentials: LoginCredentials, $authMechanism: SqlAuthenticationMechanism) {
+    result: setupCloudNativeSqlServerBackup(input: {
+        serverIds:        $serverIds,
+        databaseIds:      $databaseIds,
+        adminCredentials: $adminCredentials,
+        authMechanism:    $authMechanism
+    }) {
+        jobIds {
+            jobId
+            rubrikObjectId
+        }
+        errors {
+            error
+            rubrikObjectId
+        }
+    }
 }`
 
 // startDisableAzureCloudAccountJob GraphQL query

--- a/pkg/polaris/graphql/azure/queries/clear_cloud_native_sql_server_backup_credentials.graphql
+++ b/pkg/polaris/graphql/azure/queries/clear_cloud_native_sql_server_backup_credentials.graphql
@@ -1,0 +1,9 @@
+mutation RubrikPolarisSDKRequest($objectIds: [UUID!]!, $workloadType: WorkloadLevelHierarchy!) {
+    result: clearCloudNativeSqlServerBackupCredentials(input: {
+        objectIds:    $objectIds,
+        workloadType: $workloadType
+    }) {
+        successObjectIds
+        failedObjectIds
+    }
+}

--- a/pkg/polaris/graphql/azure/queries/setup_cloud_native_sql_server_backup.graphql
+++ b/pkg/polaris/graphql/azure/queries/setup_cloud_native_sql_server_backup.graphql
@@ -1,0 +1,17 @@
+mutation RubrikPolarisSDKRequest($serverIds: [UUID!], $databaseIds: [UUID!], $adminCredentials: LoginCredentials, $authMechanism: SqlAuthenticationMechanism) {
+    result: setupCloudNativeSqlServerBackup(input: {
+        serverIds:        $serverIds,
+        databaseIds:      $databaseIds,
+        adminCredentials: $adminCredentials,
+        authMechanism:    $authMechanism
+    }) {
+        jobIds {
+            jobId
+            rubrikObjectId
+        }
+        errors {
+            error
+            rubrikObjectId
+        }
+    }
+}

--- a/pkg/polaris/graphql/azure/sql_server.go
+++ b/pkg/polaris/graphql/azure/sql_server.go
@@ -1,0 +1,159 @@
+// Copyright 2026 Rubrik, Inc.
+//
+// Permission is hereby granted, free of charge, to any person obtaining a copy
+// of this software and associated documentation files (the "Software"), to
+// deal in the Software without restriction, including without limitation the
+// rights to use, copy, modify, merge, publish, distribute, sublicense, and/or
+// sell copies of the Software, and to permit persons to whom the Software is
+// furnished to do so, subject to the following conditions:
+//
+// The above copyright notice and this permission notice shall be included in
+// all copies or substantial portions of the Software.
+//
+// THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+// IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+// FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+// AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+// LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING
+// FROM, OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER
+// DEALINGS IN THE SOFTWARE.
+
+package azure
+
+import (
+	"context"
+	"encoding/json"
+
+	"github.com/google/uuid"
+	"github.com/rubrikinc/rubrik-polaris-sdk-for-go/pkg/polaris/graphql"
+	"github.com/rubrikinc/rubrik-polaris-sdk-for-go/pkg/polaris/graphql/core/secret"
+	"github.com/rubrikinc/rubrik-polaris-sdk-for-go/pkg/polaris/graphql/hierarchy"
+	"github.com/rubrikinc/rubrik-polaris-sdk-for-go/pkg/polaris/log"
+)
+
+// SQLAuthenticationMechanism represents the mechanism used to authenticate
+// against a SQL Server when setting up backups.
+type SQLAuthenticationMechanism string
+
+const (
+	// SQLAuthenticationUnspecified means no authentication mechanism has been
+	// specified.
+	SQLAuthenticationUnspecified SQLAuthenticationMechanism = "AUTHENTICATION_MECHANISM_UNSPECIFIED"
+
+	// SQLAuthentication authenticates using traditional SQL Server credentials.
+	SQLAuthentication SQLAuthenticationMechanism = "SQL_AUTHENTICATION"
+
+	// SQLAuthenticationEntraIDAuthCode authenticates using a Microsoft Entra ID
+	// authorization code. Using it requires an OAuth session ID, which the SDK
+	// does not support yet.
+	SQLAuthenticationEntraIDAuthCode SQLAuthenticationMechanism = "AZURE_ACTIVE_DIRECTORY_AUTH_CODE"
+)
+
+// LoginCredentials holds the login and password of a database user.
+type LoginCredentials struct {
+	Login    string        `json:"login"`
+	Password secret.String `json:"password"`
+}
+
+// AsyncJobID maps an RSC object to the job started for it.
+type AsyncJobID struct {
+	// JobID is the ID of the task chain started for the object.
+	JobID uuid.UUID `json:"jobId"`
+	// ObjectID is the RSC ID of the object the job was started for.
+	ObjectID uuid.UUID `json:"rubrikObjectId"`
+}
+
+// AsyncJobError maps an RSC object to the reason no job was started for it.
+type AsyncJobError struct {
+	Error string `json:"error"`
+	// ObjectID is the RSC ID of the object the job failed for.
+	ObjectID uuid.UUID `json:"rubrikObjectId"`
+}
+
+// BatchAsyncJobStatus is the result of starting a batch of asynchronous jobs.
+// Objects which passed pre-validation are listed in JobIDs, the rest are listed
+// in Errors.
+type BatchAsyncJobStatus struct {
+	JobIDs []AsyncJobID    `json:"jobIds"`
+	Errors []AsyncJobError `json:"errors"`
+}
+
+// SetupCloudNativeSQLServerBackup sets up backups for the specified SQL Server
+// databases or servers. Server IDs are currently only supported for Azure SQL
+// Managed Instance BAK backups.
+//
+// The admin credentials are the credentials of a database user with permission
+// to create the user RSC uses to perform backups. They are only required when
+// the authentication mechanism is SQLAuthentication.
+//
+// The returned job IDs are task chain IDs which can be passed to
+// core.API.WaitForTaskChain to wait for the setup to finish.
+func (a API) SetupCloudNativeSQLServerBackup(ctx context.Context, serverIDs, databaseIDs []uuid.UUID, adminCredentials LoginCredentials, authMechanism SQLAuthenticationMechanism) (BatchAsyncJobStatus, error) {
+	a.log.Print(log.Trace)
+
+	// The RSC API expects both ID fields to be present, so nil slices are
+	// normalized to empty slices rather than being omitted.
+	if serverIDs == nil {
+		serverIDs = []uuid.UUID{}
+	}
+	if databaseIDs == nil {
+		databaseIDs = []uuid.UUID{}
+	}
+
+	query := setupCloudNativeSqlServerBackupQuery
+	buf, err := a.GQL.Request(ctx, query, struct {
+		ServerIDs        []uuid.UUID                `json:"serverIds"`
+		DatabaseIDs      []uuid.UUID                `json:"databaseIds"`
+		AdminCredentials *LoginCredentials          `json:"adminCredentials,omitempty"`
+		AuthMechanism    SQLAuthenticationMechanism `json:"authMechanism,omitempty"`
+	}{ServerIDs: serverIDs, DatabaseIDs: databaseIDs, AdminCredentials: &adminCredentials, AuthMechanism: authMechanism})
+	if err != nil {
+		return BatchAsyncJobStatus{}, graphql.RequestError(query, err)
+	}
+
+	var payload struct {
+		Data struct {
+			Result BatchAsyncJobStatus `json:"result"`
+		} `json:"data"`
+	}
+	if err := json.Unmarshal(buf, &payload); err != nil {
+		return BatchAsyncJobStatus{}, graphql.UnmarshalError(query, err)
+	}
+
+	return payload.Data.Result, nil
+}
+
+// ClearCloudNativeSQLServerBackupCredentials clears the backup credentials of
+// the specified objects. The object IDs can refer to any level of the hierarchy
+// the credentials were set on, e.g. subscriptions, resource groups, servers or
+// databases. The workload type must match the object type the credentials apply
+// to, e.g. hierarchy.WorkloadAzureSQLMIDB for Azure SQL Managed Instances.
+//
+// Returns the IDs of the objects whose credentials were cleared and the IDs of
+// the objects whose credentials could not be cleared.
+func (a API) ClearCloudNativeSQLServerBackupCredentials(ctx context.Context, objectIDs []uuid.UUID, workloadType hierarchy.Workload) (successIDs, failedIDs []uuid.UUID, err error) {
+	a.log.Print(log.Trace)
+
+	query := clearCloudNativeSqlServerBackupCredentialsQuery
+	buf, err := a.GQL.Request(ctx, query, struct {
+		ObjectIDs    []uuid.UUID        `json:"objectIds"`
+		WorkloadType hierarchy.Workload `json:"workloadType"`
+	}{ObjectIDs: objectIDs, WorkloadType: workloadType})
+	if err != nil {
+		return nil, nil, graphql.RequestError(query, err)
+	}
+
+	var payload struct {
+		Data struct {
+			Result struct {
+				SuccessObjectIDs []uuid.UUID `json:"successObjectIds"`
+				FailedObjectIDs  []uuid.UUID `json:"failedObjectIds"`
+			} `json:"result"`
+		} `json:"data"`
+	}
+	if err := json.Unmarshal(buf, &payload); err != nil {
+		return nil, nil, graphql.UnmarshalError(query, err)
+	}
+
+	return payload.Data.Result.SuccessObjectIDs, payload.Data.Result.FailedObjectIDs, nil
+}

--- a/pkg/polaris/graphql/azure/sql_server.go
+++ b/pkg/polaris/graphql/azure/sql_server.go
@@ -100,13 +100,22 @@ func (a API) SetupCloudNativeSQLServerBackup(ctx context.Context, serverIDs, dat
 		databaseIDs = []uuid.UUID{}
 	}
 
+	// The credentials are only required for SQLAuthentication, so omit them
+	// entirely when none were given rather than sending an empty login and
+	// password. omitempty only fires for a nil pointer, it does not apply to
+	// struct values.
+	credentials := &adminCredentials
+	if adminCredentials == (LoginCredentials{}) {
+		credentials = nil
+	}
+
 	query := setupCloudNativeSqlServerBackupQuery
 	buf, err := a.GQL.Request(ctx, query, struct {
 		ServerIDs        []uuid.UUID                `json:"serverIds"`
 		DatabaseIDs      []uuid.UUID                `json:"databaseIds"`
 		AdminCredentials *LoginCredentials          `json:"adminCredentials,omitempty"`
 		AuthMechanism    SQLAuthenticationMechanism `json:"authMechanism,omitempty"`
-	}{ServerIDs: serverIDs, DatabaseIDs: databaseIDs, AdminCredentials: &adminCredentials, AuthMechanism: authMechanism})
+	}{ServerIDs: serverIDs, DatabaseIDs: databaseIDs, AdminCredentials: credentials, AuthMechanism: authMechanism})
 	if err != nil {
 		return BatchAsyncJobStatus{}, graphql.RequestError(query, err)
 	}

--- a/pkg/polaris/graphql/azure/sql_server_test.go
+++ b/pkg/polaris/graphql/azure/sql_server_test.go
@@ -27,6 +27,7 @@ import (
 	"net/http"
 	"net/http/httptest"
 	"testing"
+	"text/template"
 
 	"github.com/google/uuid"
 	"github.com/rubrikinc/rubrik-polaris-sdk-for-go/internal/assert"
@@ -35,9 +36,6 @@ import (
 	"github.com/rubrikinc/rubrik-polaris-sdk-for-go/pkg/polaris/graphql/hierarchy"
 )
 
-// Synthetic IDs whose shape mirrors what RSC returns for this mutation. The
-// shape matters: the job ID is a task chain UUID and RSC returns it as a UUIDv7
-// rather than the v4 form used elsewhere, so keep the version nibble at 7.
 const (
 	testMIServerID = "11111111-1111-4111-8111-111111111111"
 	testMIJobID    = "01900000-0000-7000-8000-000000000001"
@@ -46,22 +44,13 @@ const (
 // TestSetupCloudNativeSQLServerBackup verifies the variables sent for the SQL
 // authentication flow and that a recorded response is unmarshalled correctly.
 func TestSetupCloudNativeSQLServerBackup(t *testing.T) {
+	tmpl, err := template.ParseFiles("testdata/setup_cloud_native_sql_server_backup_response.json")
+	if err != nil {
+		t.Fatal(err)
+	}
+
 	ctx, cancel := context.WithCancelCause(context.Background())
 	defer assert.Context(t, ctx, cancel)
-
-	const response = `{
-		"data": {
-			"result": {
-				"jobIds": [
-					{
-						"jobId": "` + testMIJobID + `",
-						"rubrikObjectId": "` + testMIServerID + `"
-					}
-				],
-				"errors": []
-			}
-		}
-	}`
 
 	var gotVars struct {
 		ServerIDs        []string `json:"serverIds"`
@@ -75,18 +64,27 @@ func TestSetupCloudNativeSQLServerBackup(t *testing.T) {
 	srv := httptest.NewServer(handler.GraphQL(func(w http.ResponseWriter, req *http.Request) {
 		body, err := io.ReadAll(req.Body)
 		if err != nil {
-			t.Fatalf("read request body: %v", err)
+			cancel(err)
+			return
 		}
 		var decoded struct {
 			Variables json.RawMessage `json:"variables"`
 		}
 		if err := json.Unmarshal(body, &decoded); err != nil {
-			t.Fatalf("unmarshal request body: %v", err)
+			cancel(err)
+			return
 		}
 		if err := json.Unmarshal(decoded.Variables, &gotVars); err != nil {
-			t.Fatalf("unmarshal variables: %v", err)
+			cancel(err)
+			return
 		}
-		io.WriteString(w, response)
+
+		if err := tmpl.Execute(w, struct {
+			JobID    string
+			ServerID string
+		}{JobID: testMIJobID, ServerID: testMIServerID}); err != nil {
+			cancel(err)
+		}
 	}))
 	defer srv.Close()
 
@@ -138,25 +136,21 @@ func TestSetupCloudNativeSQLServerBackup(t *testing.T) {
 // TestSetupCloudNativeSQLServerBackupPreValidationError verifies that an object
 // which fails pre-validation is returned in Errors with no job started.
 func TestSetupCloudNativeSQLServerBackupPreValidationError(t *testing.T) {
+	tmpl, err := template.ParseFiles("testdata/setup_cloud_native_sql_server_backup_pre_validation_error_response.json")
+	if err != nil {
+		t.Fatal(err)
+	}
+
 	ctx, cancel := context.WithCancelCause(context.Background())
 	defer assert.Context(t, ctx, cancel)
 
-	const response = `{
-		"data": {
-			"result": {
-				"jobIds": [],
-				"errors": [
-					{
-						"error": "invalid credentials",
-						"rubrikObjectId": "` + testMIServerID + `"
-					}
-				]
-			}
-		}
-	}`
-
 	srv := httptest.NewServer(handler.GraphQL(func(w http.ResponseWriter, req *http.Request) {
-		io.WriteString(w, response)
+		if err := tmpl.Execute(w, struct {
+			Error    string
+			ServerID string
+		}{Error: "invalid credentials", ServerID: testMIServerID}); err != nil {
+			cancel(err)
+		}
 	}))
 	defer srv.Close()
 
@@ -185,19 +179,15 @@ func TestSetupCloudNativeSQLServerBackupPreValidationError(t *testing.T) {
 // type is sent using its GraphQL enum name and that the reply is split into
 // successful and failed object IDs.
 func TestClearCloudNativeSQLServerBackupCredentials(t *testing.T) {
+	tmpl, err := template.ParseFiles("testdata/clear_cloud_native_sql_server_backup_credentials_response.json")
+	if err != nil {
+		t.Fatal(err)
+	}
+
 	ctx, cancel := context.WithCancelCause(context.Background())
 	defer assert.Context(t, ctx, cancel)
 
 	const failedID = "22222222-2222-4222-8222-222222222222"
-
-	const response = `{
-		"data": {
-			"result": {
-				"successObjectIds": ["` + testMIServerID + `"],
-				"failedObjectIds": ["` + failedID + `"]
-			}
-		}
-	}`
 
 	var gotVars struct {
 		ObjectIDs    []string `json:"objectIds"`
@@ -206,18 +196,27 @@ func TestClearCloudNativeSQLServerBackupCredentials(t *testing.T) {
 	srv := httptest.NewServer(handler.GraphQL(func(w http.ResponseWriter, req *http.Request) {
 		body, err := io.ReadAll(req.Body)
 		if err != nil {
-			t.Fatalf("read request body: %v", err)
+			cancel(err)
+			return
 		}
 		var decoded struct {
 			Variables json.RawMessage `json:"variables"`
 		}
 		if err := json.Unmarshal(body, &decoded); err != nil {
-			t.Fatalf("unmarshal request body: %v", err)
+			cancel(err)
+			return
 		}
 		if err := json.Unmarshal(decoded.Variables, &gotVars); err != nil {
-			t.Fatalf("unmarshal variables: %v", err)
+			cancel(err)
+			return
 		}
-		io.WriteString(w, response)
+
+		if err := tmpl.Execute(w, struct {
+			SuccessID string
+			FailedID  string
+		}{SuccessID: testMIServerID, FailedID: failedID}); err != nil {
+			cancel(err)
+		}
 	}))
 	defer srv.Close()
 

--- a/pkg/polaris/graphql/azure/sql_server_test.go
+++ b/pkg/polaris/graphql/azure/sql_server_test.go
@@ -41,6 +41,32 @@ const (
 	testMIJobID    = "01900000-0000-7000-8000-000000000001"
 )
 
+// decodeVars decodes the GraphQL request variables into vars. It is called from
+// the httptest handler goroutine, so failures cancel the context with the cause
+// instead of failing the test directly. Returns false when the request could
+// not be decoded, in which case the handler must return without responding.
+func decodeVars(cancel context.CancelCauseFunc, req *http.Request, vars any) bool {
+	body, err := io.ReadAll(req.Body)
+	if err != nil {
+		cancel(err)
+		return false
+	}
+
+	var decoded struct {
+		Variables json.RawMessage `json:"variables"`
+	}
+	if err := json.Unmarshal(body, &decoded); err != nil {
+		cancel(err)
+		return false
+	}
+	if err := json.Unmarshal(decoded.Variables, vars); err != nil {
+		cancel(err)
+		return false
+	}
+
+	return true
+}
+
 // TestSetupCloudNativeSQLServerBackup verifies the variables sent for the SQL
 // authentication flow and that a recorded response is unmarshalled correctly.
 func TestSetupCloudNativeSQLServerBackup(t *testing.T) {
@@ -62,20 +88,7 @@ func TestSetupCloudNativeSQLServerBackup(t *testing.T) {
 		AuthMechanism string `json:"authMechanism"`
 	}
 	srv := httptest.NewServer(handler.GraphQL(func(w http.ResponseWriter, req *http.Request) {
-		body, err := io.ReadAll(req.Body)
-		if err != nil {
-			cancel(err)
-			return
-		}
-		var decoded struct {
-			Variables json.RawMessage `json:"variables"`
-		}
-		if err := json.Unmarshal(body, &decoded); err != nil {
-			cancel(err)
-			return
-		}
-		if err := json.Unmarshal(decoded.Variables, &gotVars); err != nil {
-			cancel(err)
+		if !decodeVars(cancel, req, &gotVars) {
 			return
 		}
 
@@ -194,20 +207,7 @@ func TestClearCloudNativeSQLServerBackupCredentials(t *testing.T) {
 		WorkloadType string   `json:"workloadType"`
 	}
 	srv := httptest.NewServer(handler.GraphQL(func(w http.ResponseWriter, req *http.Request) {
-		body, err := io.ReadAll(req.Body)
-		if err != nil {
-			cancel(err)
-			return
-		}
-		var decoded struct {
-			Variables json.RawMessage `json:"variables"`
-		}
-		if err := json.Unmarshal(body, &decoded); err != nil {
-			cancel(err)
-			return
-		}
-		if err := json.Unmarshal(decoded.Variables, &gotVars); err != nil {
-			cancel(err)
+		if !decodeVars(cancel, req, &gotVars) {
 			return
 		}
 

--- a/pkg/polaris/graphql/azure/sql_server_test.go
+++ b/pkg/polaris/graphql/azure/sql_server_test.go
@@ -1,0 +1,244 @@
+// Copyright 2026 Rubrik, Inc.
+//
+// Permission is hereby granted, free of charge, to any person obtaining a copy
+// of this software and associated documentation files (the "Software"), to
+// deal in the Software without restriction, including without limitation the
+// rights to use, copy, modify, merge, publish, distribute, sublicense, and/or
+// sell copies of the Software, and to permit persons to whom the Software is
+// furnished to do so, subject to the following conditions:
+//
+// The above copyright notice and this permission notice shall be included in
+// all copies or substantial portions of the Software.
+//
+// THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+// IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+// FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+// AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+// LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING
+// FROM, OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER
+// DEALINGS IN THE SOFTWARE.
+
+package azure
+
+import (
+	"context"
+	"encoding/json"
+	"io"
+	"net/http"
+	"net/http/httptest"
+	"testing"
+
+	"github.com/google/uuid"
+	"github.com/rubrikinc/rubrik-polaris-sdk-for-go/internal/assert"
+	"github.com/rubrikinc/rubrik-polaris-sdk-for-go/internal/handler"
+	"github.com/rubrikinc/rubrik-polaris-sdk-for-go/pkg/polaris/graphql"
+	"github.com/rubrikinc/rubrik-polaris-sdk-for-go/pkg/polaris/graphql/hierarchy"
+)
+
+// Synthetic IDs whose shape mirrors what RSC returns for this mutation. The
+// shape matters: the job ID is a task chain UUID and RSC returns it as a UUIDv7
+// rather than the v4 form used elsewhere, so keep the version nibble at 7.
+const (
+	testMIServerID = "11111111-1111-4111-8111-111111111111"
+	testMIJobID    = "01900000-0000-7000-8000-000000000001"
+)
+
+// TestSetupCloudNativeSQLServerBackup verifies the variables sent for the SQL
+// authentication flow and that a recorded response is unmarshalled correctly.
+func TestSetupCloudNativeSQLServerBackup(t *testing.T) {
+	ctx, cancel := context.WithCancelCause(context.Background())
+	defer assert.Context(t, ctx, cancel)
+
+	const response = `{
+		"data": {
+			"result": {
+				"jobIds": [
+					{
+						"jobId": "` + testMIJobID + `",
+						"rubrikObjectId": "` + testMIServerID + `"
+					}
+				],
+				"errors": []
+			}
+		}
+	}`
+
+	var gotVars struct {
+		ServerIDs        []string `json:"serverIds"`
+		DatabaseIDs      []string `json:"databaseIds"`
+		AdminCredentials struct {
+			Login    string `json:"login"`
+			Password string `json:"password"`
+		} `json:"adminCredentials"`
+		AuthMechanism string `json:"authMechanism"`
+	}
+	srv := httptest.NewServer(handler.GraphQL(func(w http.ResponseWriter, req *http.Request) {
+		body, err := io.ReadAll(req.Body)
+		if err != nil {
+			t.Fatalf("read request body: %v", err)
+		}
+		var decoded struct {
+			Variables json.RawMessage `json:"variables"`
+		}
+		if err := json.Unmarshal(body, &decoded); err != nil {
+			t.Fatalf("unmarshal request body: %v", err)
+		}
+		if err := json.Unmarshal(decoded.Variables, &gotVars); err != nil {
+			t.Fatalf("unmarshal variables: %v", err)
+		}
+		io.WriteString(w, response)
+	}))
+	defer srv.Close()
+
+	serverID := uuid.MustParse(testMIServerID)
+	status, err := Wrap(graphql.NewTestClient(srv)).SetupCloudNativeSQLServerBackup(ctx,
+		[]uuid.UUID{serverID}, nil, LoginCredentials{Login: "draper", Password: "s3cret"}, SQLAuthentication)
+	if err != nil {
+		t.Fatalf("SetupCloudNativeSQLServerBackup failed: %v", err)
+	}
+
+	if len(gotVars.ServerIDs) != 1 || gotVars.ServerIDs[0] != testMIServerID {
+		t.Errorf("serverIds: got %v", gotVars.ServerIDs)
+	}
+	// RSC expects databaseIds to be present and empty for the instance-level
+	// flow, not omitted. A nil slice and an empty slice both format as [], so
+	// report the two cases distinctly.
+	switch {
+	case gotVars.DatabaseIDs == nil:
+		t.Error("databaseIds: omitted from the request, want an empty array")
+	case len(gotVars.DatabaseIDs) != 0:
+		t.Errorf("databaseIds: got %v, want an empty array", gotVars.DatabaseIDs)
+	}
+	if gotVars.AdminCredentials.Login != "draper" {
+		t.Errorf("adminCredentials.login: got %q", gotVars.AdminCredentials.Login)
+	}
+	// secret.String must still send the real value over the wire, it is only
+	// redacted when logged.
+	if gotVars.AdminCredentials.Password != "s3cret" {
+		t.Errorf("adminCredentials.password was not sent verbatim")
+	}
+	if gotVars.AuthMechanism != "SQL_AUTHENTICATION" {
+		t.Errorf("authMechanism: got %q", gotVars.AuthMechanism)
+	}
+
+	if len(status.Errors) != 0 {
+		t.Errorf("errors: got %v, want none", status.Errors)
+	}
+	if len(status.JobIDs) != 1 {
+		t.Fatalf("got %d job IDs, want 1", len(status.JobIDs))
+	}
+	if status.JobIDs[0].JobID != uuid.MustParse(testMIJobID) {
+		t.Errorf("jobId: got %q", status.JobIDs[0].JobID)
+	}
+	if status.JobIDs[0].ObjectID != serverID {
+		t.Errorf("rubrikObjectId: got %q", status.JobIDs[0].ObjectID)
+	}
+}
+
+// TestSetupCloudNativeSQLServerBackupPreValidationError verifies that an object
+// which fails pre-validation is returned in Errors with no job started.
+func TestSetupCloudNativeSQLServerBackupPreValidationError(t *testing.T) {
+	ctx, cancel := context.WithCancelCause(context.Background())
+	defer assert.Context(t, ctx, cancel)
+
+	const response = `{
+		"data": {
+			"result": {
+				"jobIds": [],
+				"errors": [
+					{
+						"error": "invalid credentials",
+						"rubrikObjectId": "` + testMIServerID + `"
+					}
+				]
+			}
+		}
+	}`
+
+	srv := httptest.NewServer(handler.GraphQL(func(w http.ResponseWriter, req *http.Request) {
+		io.WriteString(w, response)
+	}))
+	defer srv.Close()
+
+	status, err := Wrap(graphql.NewTestClient(srv)).SetupCloudNativeSQLServerBackup(ctx,
+		[]uuid.UUID{uuid.MustParse(testMIServerID)}, nil, LoginCredentials{Login: "draper", Password: "s3cret"},
+		SQLAuthentication)
+	if err != nil {
+		t.Fatalf("SetupCloudNativeSQLServerBackup failed: %v", err)
+	}
+
+	if len(status.JobIDs) != 0 {
+		t.Errorf("job IDs: got %v, want none", status.JobIDs)
+	}
+	if len(status.Errors) != 1 {
+		t.Fatalf("got %d errors, want 1", len(status.Errors))
+	}
+	if status.Errors[0].Error != "invalid credentials" {
+		t.Errorf("error: got %q", status.Errors[0].Error)
+	}
+	if status.Errors[0].ObjectID != uuid.MustParse(testMIServerID) {
+		t.Errorf("rubrikObjectId: got %q", status.Errors[0].ObjectID)
+	}
+}
+
+// TestClearCloudNativeSQLServerBackupCredentials verifies that the workload
+// type is sent using its GraphQL enum name and that the reply is split into
+// successful and failed object IDs.
+func TestClearCloudNativeSQLServerBackupCredentials(t *testing.T) {
+	ctx, cancel := context.WithCancelCause(context.Background())
+	defer assert.Context(t, ctx, cancel)
+
+	const failedID = "22222222-2222-4222-8222-222222222222"
+
+	const response = `{
+		"data": {
+			"result": {
+				"successObjectIds": ["` + testMIServerID + `"],
+				"failedObjectIds": ["` + failedID + `"]
+			}
+		}
+	}`
+
+	var gotVars struct {
+		ObjectIDs    []string `json:"objectIds"`
+		WorkloadType string   `json:"workloadType"`
+	}
+	srv := httptest.NewServer(handler.GraphQL(func(w http.ResponseWriter, req *http.Request) {
+		body, err := io.ReadAll(req.Body)
+		if err != nil {
+			t.Fatalf("read request body: %v", err)
+		}
+		var decoded struct {
+			Variables json.RawMessage `json:"variables"`
+		}
+		if err := json.Unmarshal(body, &decoded); err != nil {
+			t.Fatalf("unmarshal request body: %v", err)
+		}
+		if err := json.Unmarshal(decoded.Variables, &gotVars); err != nil {
+			t.Fatalf("unmarshal variables: %v", err)
+		}
+		io.WriteString(w, response)
+	}))
+	defer srv.Close()
+
+	successIDs, failedIDs, err := Wrap(graphql.NewTestClient(srv)).ClearCloudNativeSQLServerBackupCredentials(ctx,
+		[]uuid.UUID{uuid.MustParse(testMIServerID)}, hierarchy.WorkloadAzureSQLMIDB)
+	if err != nil {
+		t.Fatalf("ClearCloudNativeSQLServerBackupCredentials failed: %v", err)
+	}
+
+	if len(gotVars.ObjectIDs) != 1 || gotVars.ObjectIDs[0] != testMIServerID {
+		t.Errorf("objectIds: got %v", gotVars.ObjectIDs)
+	}
+	// The GraphQL enum name, not the SDK string value AZURE_SQL_MANAGED_INSTANCE_DB.
+	if gotVars.WorkloadType != "AzureSqlManagedInstanceDb" {
+		t.Errorf("workloadType: got %q, want %q", gotVars.WorkloadType, "AzureSqlManagedInstanceDb")
+	}
+
+	if len(successIDs) != 1 || successIDs[0] != uuid.MustParse(testMIServerID) {
+		t.Errorf("successObjectIds: got %v", successIDs)
+	}
+	if len(failedIDs) != 1 || failedIDs[0] != uuid.MustParse(failedID) {
+		t.Errorf("failedObjectIds: got %v", failedIDs)
+	}
+}

--- a/pkg/polaris/graphql/azure/testdata/clear_cloud_native_sql_server_backup_credentials_response.json
+++ b/pkg/polaris/graphql/azure/testdata/clear_cloud_native_sql_server_backup_credentials_response.json
@@ -1,0 +1,8 @@
+{
+    "data": {
+        "result": {
+            "successObjectIds": ["{{ .SuccessID }}"],
+            "failedObjectIds": ["{{ .FailedID }}"]
+        }
+    }
+}

--- a/pkg/polaris/graphql/azure/testdata/setup_cloud_native_sql_server_backup_pre_validation_error_response.json
+++ b/pkg/polaris/graphql/azure/testdata/setup_cloud_native_sql_server_backup_pre_validation_error_response.json
@@ -1,0 +1,13 @@
+{
+    "data": {
+        "result": {
+            "jobIds": [],
+            "errors": [
+                {
+                    "error": "{{ .Error }}",
+                    "rubrikObjectId": "{{ .ServerID }}"
+                }
+            ]
+        }
+    }
+}

--- a/pkg/polaris/graphql/azure/testdata/setup_cloud_native_sql_server_backup_response.json
+++ b/pkg/polaris/graphql/azure/testdata/setup_cloud_native_sql_server_backup_response.json
@@ -1,0 +1,13 @@
+{
+    "data": {
+        "result": {
+            "jobIds": [
+                {
+                    "jobId": "{{ .JobID }}",
+                    "rubrikObjectId": "{{ .ServerID }}"
+                }
+            ],
+            "errors": []
+        }
+    }
+}


### PR DESCRIPTION
## Summary

Adds support for configuring RSC to back up Azure SQL Managed Instance servers using SQL Server authentication, and for clearing those credentials again. Follow-up to #399 and #402, which made the servers discoverable.

## Changes

Both live in the existing `azure` packages rather than a new one:

- `pkg/polaris/graphql/azure/sql_server.go` + two queries — thin wrappers around `setupCloudNativeSqlServerBackup` and `clearCloudNativeSqlServerBackupCredentials`.
- `pkg/polaris/azure/sql_server.go` — `SetupSQLManagedInstanceBackup`, which starts the setup and blocks on `core.WaitForTaskChain` until every task chain reaches a terminal state, and `ClearSQLManagedInstanceBackupCredentials`.

## Notes

- The setup mutation is asynchronous: it returns one task chain per object that passed pre-validation, plus the objects that did not. Both are surfaced — pre-validation failures never get a task chain, so they would otherwise be silently dropped.
- `databaseIds` is sent as an empty array rather than omitted for the instance-level flow, which is what RSC expects. There is a test for this specifically.
- Reuses the existing `hierarchy.WorkloadAzureSQLMIDB` constant, which already marshals to the `AzureSqlManagedInstanceDb` GraphQL enum name — no new enum.
- Passwords use `secret.String`, so they are redacted in logs but still sent verbatim.
- Credentials are only validated by the managed instance once the task chain runs, so bad credentials fail the task chain rather than the request. The error message says so, because the failure is otherwise quite opaque.
- Entra ID authentication needs an OAuth session ID and is not supported yet. The enum constant is defined but unused.

This is the first caller of `core.WaitForTaskChain`, which existed but was unused.

## Testing

- **Unit:** three tests against the mock GraphQL server, covering the request variables, a pre-validation error response, and the workload enum name. Fixtures — including the UUIDv7 task chain ID — are taken from a recorded RSC session rather than hand-written, and I verified the `databaseIds` assertion actually fails when the normalization is removed. Hand-written fixtures are exactly what let the `tenantId` bug fixed in #402 reach main.
- **Live (dev RSC, identifiers omitted):** driven end to end through the Terraform resource that consumes this. The task chain was polled to completion and a failed setup surfaced as a clear error naming the server, rather than a silent success.

## Not yet proven

The **success** path needs a valid SQL administrator login on the managed instance; the credentials available so far are invalid, so only the failure path has been exercised live.