### PR TITLE
Add AZURE_POSTGRES_FLEXIBLE_SERVER_PROTECTION feature

### DIFF
--- a/pkg/polaris/azure/cloud_account.go
+++ b/pkg/polaris/azure/cloud_account.go
@@ -102,9 +102,12 @@ func (f Feature) SupportResourceGroup() bool {
 }
 
 // SupportUserAssignedManagedIdentity returns true if the feature supports
-// being onboarded with user-assigned managed identity.
+// being onboarded with user-assigned managed identity. Note, RSC requires an
+// identity for AZURE_POSTGRES_FLEXIBLE_SERVER_PROTECTION and it must belong to
+// the same resource group as the feature.
 func (f Feature) SupportUserAssignedManagedIdentity() bool {
-	return f.Equal(core.FeatureCloudNativeArchivalEncryption)
+	return f.Equal(core.FeatureAzurePostgresFlexibleServerProtection) ||
+		f.Equal(core.FeatureCloudNativeArchivalEncryption)
 }
 
 type FeatureResourceGroup struct {
@@ -620,6 +623,7 @@ func (a API) SetServicePrincipal(ctx context.Context, principal ServicePrincipal
 // SupportedFeatures returns the features supported by Azure cloud accounts.
 func SupportedFeatures() []core.Feature {
 	return []core.Feature{
+		core.FeatureAzurePostgresFlexibleServerProtection,
 		core.FeatureAzureSQLDBProtection,
 		core.FeatureAzureSQLMIProtection,
 		core.FeatureCloudDiscovery,

--- a/pkg/polaris/azure/cloud_account_test.go
+++ b/pkg/polaris/azure/cloud_account_test.go
@@ -980,6 +980,60 @@ func TestToSubscription(t *testing.T) {
 	}
 }
 
+func TestFeatureOnboardingRequirements(t *testing.T) {
+	tt := []struct {
+		feature                core.Feature
+		supportResourceGroup   bool
+		supportManagedIdentity bool
+	}{{
+		feature:                core.FeatureAzurePostgresFlexibleServerProtection,
+		supportResourceGroup:   true,
+		supportManagedIdentity: true,
+	}, {
+		feature:                core.FeatureCloudNativeArchivalEncryption,
+		supportResourceGroup:   true,
+		supportManagedIdentity: true,
+	}, {
+		feature:                core.FeatureAzureSQLMIProtection,
+		supportResourceGroup:   false,
+		supportManagedIdentity: false,
+	}, {
+		feature:                core.FeatureCloudNativeBlobProtection,
+		supportResourceGroup:   false,
+		supportManagedIdentity: false,
+	}, {
+		feature:                core.FeatureCloudDiscovery,
+		supportResourceGroup:   false,
+		supportManagedIdentity: false,
+	}, {
+		feature:                core.FeatureCloudNativeProtection,
+		supportResourceGroup:   true,
+		supportManagedIdentity: false,
+	}}
+
+	for _, tc := range tt {
+		t.Run(tc.feature.Name, func(t *testing.T) {
+			feature := Feature{Feature: tc.feature}
+			if got := feature.SupportResourceGroup(); got != tc.supportResourceGroup {
+				t.Errorf("SupportResourceGroup() = %t, want %t", got, tc.supportResourceGroup)
+			}
+			if got := feature.SupportUserAssignedManagedIdentity(); got != tc.supportManagedIdentity {
+				t.Errorf("SupportUserAssignedManagedIdentity() = %t, want %t", got, tc.supportManagedIdentity)
+			}
+		})
+	}
+}
+
+// TestSupportedFeaturesIncludesPostgresFlexibleServer guards against the
+// Postgres flexible server feature being dropped from SupportedFeatures. The
+// list doubles as a read filter in toSubscriptions, so a missing entry silently
+// omits the feature from the returned cloud account rather than failing loudly.
+func TestSupportedFeaturesIncludesPostgresFlexibleServer(t *testing.T) {
+	if _, ok := core.LookupFeature(SupportedFeatures(), core.FeatureAzurePostgresFlexibleServerProtection); !ok {
+		t.Error("AZURE_POSTGRES_FLEXIBLE_SERVER_PROTECTION missing from SupportedFeatures")
+	}
+}
+
 func TestToTenant(t *testing.T) {
 	rawTenants, err := allAzureCloudAccountTenantsResponse()
 	if err != nil {

--- a/pkg/polaris/graphql/core/feature.go
+++ b/pkg/polaris/graphql/core/feature.go
@@ -84,6 +84,7 @@ var (
 	FeatureAzureDevOpsDeveloperCollaborationProtection = Feature{Name: "AZURE_DEVOPS_DEVELOPER_COLLABORATION_PROTECTION"}
 	FeatureAzureDevOpsProtection                       = Feature{Name: "AZURE_DEVOPS_PROTECTION"} // Deprecated: use FeatureAzureDevOpsRepositoryProtection
 	FeatureAzureDevOpsRepositoryProtection             = Feature{Name: "AZURE_DEVOPS_REPOSITORY_PROTECTION"}
+	FeatureAzurePostgresFlexibleServerProtection       = Feature{Name: "AZURE_POSTGRES_FLEXIBLE_SERVER_PROTECTION"}
 	FeatureAzureSQLDBProtection                        = Feature{Name: "AZURE_SQL_DB_PROTECTION"}
 	FeatureAzureSQLMIProtection                        = Feature{Name: "AZURE_SQL_MI_PROTECTION"}
 	FeatureCloudAccounts                               = Feature{Name: "CLOUDACCOUNTS"} // Deprecated: no replacement.
@@ -164,6 +165,7 @@ func (f Feature) IsProtectionFeature() bool {
 		FeatureAzureDevOpsDeveloperCollaborationProtection,
 		FeatureAzureDevOpsProtection,
 		FeatureAzureDevOpsRepositoryProtection,
+		FeatureAzurePostgresFlexibleServerProtection,
 		FeatureAzureSQLDBProtection,
 		FeatureAzureSQLMIProtection,
 		FeatureCloudDiscovery,
@@ -219,6 +221,7 @@ func AllProtectionFeatures(cloud CloudVendor) []Feature {
 		}
 	case CloudVendorAzure:
 		return []Feature{
+			FeatureAzurePostgresFlexibleServerProtection,
 			FeatureAzureSQLDBProtection,
 			FeatureAzureSQLMIProtection,
 			FeatureCloudNativeBlobProtection,
@@ -300,6 +303,7 @@ var validFeatures = map[string]struct{}{
 	FeatureAzureDevOpsDeveloperCollaborationProtection.Name: {},
 	FeatureAzureDevOpsProtection.Name:                       {}, // Deprecated: use FeatureAzureDevOpsRepositoryProtection
 	FeatureAzureDevOpsRepositoryProtection.Name:             {},
+	FeatureAzurePostgresFlexibleServerProtection.Name:       {},
 	FeatureAzureSQLDBProtection.Name:                        {},
 	FeatureAzureSQLMIProtection.Name:                        {},
 	FeatureCloudAccounts.Name:                               {}, // Deprecated: no replacement.

--- a/pkg/polaris/graphql/core/feature_flag.go
+++ b/pkg/polaris/graphql/core/feature_flag.go
@@ -35,6 +35,7 @@ type FeatureFlagName string
 const (
 	FeatureFlagAWSManualRoleChaining           FeatureFlagName = "REL_ENABLE_AWS_MANUAL_ROLE_CHAINING"
 	FeatureFlagAzureDevOpsProtection           FeatureFlagName = "AZURE_DEVOPS_PROTECTION_ENABLED"
+	FeatureFlagAzurePostgresFlexibleServer     FeatureFlagName = "REL_ENABLE_AZURE_POSTGRES_FLEXIBLE_SERVER"
 	FeatureFlagAzureSQLDBCopyBackup            FeatureFlagName = "CNP_AZURE_SQL_DB_COPY_BACKUP"
 	FeatureFlagAzureSQLSLARevamp               FeatureFlagName = "CNP_AZURE_SQL_SLA_REVAMP"
 	FeatureFlagMultipleKeyValuePairsInTagRules FeatureFlagName = "CNP_MULTIPLE_KEY_VALUE_PAIRS_IN_TAG_RULES_ENABLED"


### PR DESCRIPTION
# Description

Adds the `AZURE_POSTGRES_FLEXIBLE_SERVER_PROTECTION` feature so it can be onboarded on an Azure subscription and have its permissions generated.

RSC accepts the feature through the existing add-subscription mutation and permission queries, all of which take the feature as a variable, so no GraphQL changes are needed.

Two onboarding requirements are stricter than the comparable Azure SQL DB feature, and both are unconditional rather than feature-flag gated:

* A resource group is required. `SupportResourceGroup` already returns true for the feature, since it is a negative list.
* A user-assigned managed identity is required, and it must belong to the same resource group as the feature. `SupportUserAssignedManagedIdentity` is updated accordingly.

The feature is gated in RSC behind `REL_ENABLE_AZURE_POSTGRES_FLEXIBLE_SERVER`, added here as a `FeatureFlagName` so callers can check it before attempting to onboard.

`SupportUserAssignedManagedIdentity` still omits `AZURE_SQL_DB_PROTECTION`, which also supports an identity. That is a pre-existing gap, harmless today because the function has no callers outside this repository, and is deliberately left for a separate change rather than folded in here.

## Related Issue

No existing issue. This is the first of three stacked SDK PRs supporting Terraform for Azure Postgres flexible servers. Happy to open a tracking issue if the project requires one before merge.

## Motivation and Context

Terraform users have no way to onboard the feature, generate its Azure role definition, or assign an SLA domain to a Postgres flexible server. Azure SQL DB and SQL MI already have all three. This PR is the SDK groundwork.

The requirements above were read from the RSC backend rather than inferred, because the introspected GraphQL schema alone is misleading on both points:

* `IsResourceGroupRequiredForFeature` returns true unconditionally; the add validator rejects a nil resource group.
* `IsUserAssignedIdentityRequiredForFeature` returns true unconditionally, and `validateFeatureUMIInput` additionally requires the identity's resource group to equal the feature's.

## How Has This Been Tested?

* `go fmt`, `go vet`, `go build ./...` and `go test ./...` all clean.
* `TestFeatureOnboardingRequirements` covers the resource group and managed identity predicates across six features, pinning the SQL MI, blob and cloud discovery cases as well as the new one.
* `TestSupportedFeaturesIncludesPostgresFlexibleServer` guards the feature staying in `SupportedFeatures`. That list doubles as a read filter in `toSubscriptions`, so a missing entry would silently omit the feature from a cloud account rather than failing.
* Verified against a live RSC deployment that `REL_ENABLE_AZURE_POSTGRES_FLEXIBLE_SERVER` resolves through the new `FeatureFlagName` constant.
* `TestFindAccount` in `pkg/polaris` fails both with and without this change on my machine, because it reads the local `~/.rubrik` service account files. Unrelated to this PR.

## Types of changes

- [ ] Bug fix (non-breaking change which fixes an issue)
- [x] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)
- [ ] Other (please describe in the Description above)

## Checklist:

- [x] My code follows the code style of this project.
- [ ] My change requires a change to the documentation.
- [ ] I have updated the documentation accordingly.
- [ ] I have updated the CHANGELOG file accordingly for the version that this merge modifies.
- [x] I have added tests to cover my changes.
- [x] All new and existing tests passed.
