### PR TITLE
Add AzurePostgresFlexibleServer inventory object

### DIFF
--- a/pkg/polaris/graphql/hierarchy/hierarchy.go
+++ b/pkg/polaris/graphql/hierarchy/hierarchy.go
@@ -194,6 +194,7 @@ type InventoryObject interface {
 		AzureNativeResourceGroup |
 		AzureNativeSubscription |
 		AzureNativeVirtualMachine |
+		AzurePostgresFlexibleServer |
 		AzureSQLManagedInstanceServer |
 		CloudNativeTagRule |
 		GitHubOrganization |
@@ -371,6 +372,21 @@ type AzureSubscriptionDetails struct {
 	RegionSpecs []struct {
 		Region azureregions.NativeRegionEnum `json:"region"`
 	} `json:"regionSpecs"`
+}
+
+// AzurePostgresFlexibleServer represents an Azure Postgres flexible server from
+// the inventory root. In addition to the common object fields it exposes the
+// parent subscription details, so callers can filter servers by subscription
+// client-side — the inventory query has no subscription filter.
+type AzurePostgresFlexibleServer struct {
+	Object
+	ResourceGroup struct {
+		Subscription AzureSubscriptionDetails `json:"azureSubscriptionDetails"`
+	} `json:"azureResourceGroupDetails"`
+}
+
+func (AzurePostgresFlexibleServer) typeFilter() ObjectType {
+	return "AZURE_POSTGRES_FLEXIBLE_SERVER"
 }
 
 // AzureSQLManagedInstanceServer represents an Azure SQL Managed Instance server

--- a/pkg/polaris/graphql/hierarchy/hierarchy_test.go
+++ b/pkg/polaris/graphql/hierarchy/hierarchy_test.go
@@ -99,6 +99,68 @@ func TestObjectsByName(t *testing.T) {
 	}
 }
 
+// TestAzurePostgresFlexibleServer verifies the type's inventory type filter and
+// that an API response unmarshals into the type, including the parent
+// subscription details.
+func TestAzurePostgresFlexibleServer(t *testing.T) {
+	// InventoryObject is a constraint interface, so it can't be used as a
+	// variable type; call typeFilter directly on the value instead. Note that
+	// RSC spells this HierarchyObjectTypeEnum value in SCREAMING_SNAKE_CASE,
+	// unlike the CamelCase AzureSqlManagedInstanceServer value.
+	if typeFilter := (AzurePostgresFlexibleServer{}).typeFilter(); typeFilter != "AZURE_POSTGRES_FLEXIBLE_SERVER" {
+		t.Fatalf("wrong type filter: %s", typeFilter)
+	}
+
+	const res = `{
+		"id": "11111111-1111-1111-1111-111111111111",
+		"name": "example-flex-server",
+		"objectType": "AZURE_POSTGRES_FLEXIBLE_SERVER",
+		"azureResourceGroupDetails": {
+			"azureSubscriptionDetails": {
+				"id": "22222222-2222-2222-2222-222222222222",
+				"name": "example-subscription",
+				"accountConnectionId": "33333333-3333-3333-3333-333333333333",
+				"tenantId": "example.onmicrosoft.com",
+				"cloudType": "AZUREPUBLICCLOUD",
+				"status": "REFRESHED",
+				"regionSpecs": [{"region": "EAST_US2"}]
+			}
+		}
+	}`
+
+	var obj AzurePostgresFlexibleServer
+	if err := json.Unmarshal([]byte(res), &obj); err != nil {
+		t.Fatal(err)
+	}
+
+	if obj.Name != "example-flex-server" {
+		t.Errorf("name: got %q", obj.Name)
+	}
+	if obj.ObjectType != "AZURE_POSTGRES_FLEXIBLE_SERVER" {
+		t.Errorf("objectType: got %q", obj.ObjectType)
+	}
+
+	// The subscription details drive the client-side subscription filtering
+	// callers do, since the inventory query has no subscription filter.
+	sub := obj.ResourceGroup.Subscription
+	if sub.CloudAccountID != uuid.MustParse("33333333-3333-3333-3333-333333333333") {
+		t.Errorf("subscription cloud account ID: got %q", sub.CloudAccountID)
+	}
+	// RSC returns the tenant domain, not a UUID, in the tenantId field.
+	if sub.TenantDomain != "example.onmicrosoft.com" {
+		t.Errorf("subscription tenant domain: got %q", sub.TenantDomain)
+	}
+	if sub.Cloud != "AZUREPUBLICCLOUD" {
+		t.Errorf("subscription cloud: got %q, want %q", sub.Cloud, "AZUREPUBLICCLOUD")
+	}
+	// Compare against the region constant rather than round-tripping the same
+	// string through RegionFromNativeRegionEnum, which would pass vacuously if
+	// both sides resolved to RegionUnknown.
+	if len(sub.RegionSpecs) != 1 || sub.RegionSpecs[0].Region.Region != azureregions.RegionEastUS2 {
+		t.Errorf("region specs: got %+v, want [EAST_US2]", sub.RegionSpecs)
+	}
+}
+
 // TestAzureSQLManagedInstanceServer verifies the type's inventory type filter
 // and that an API response unmarshals into the type, including the parent
 // subscription details.

--- a/pkg/polaris/graphql/hierarchy/queries.go
+++ b/pkg/polaris/graphql/hierarchy/queries.go
@@ -168,6 +168,21 @@ var inventoryRootQuery = `query SdkGolangInventoryRoot($after: String, $filter: 
                         }
                     }
                 }
+                ... on AzurePostgresFlexibleServer {
+                    azureResourceGroupDetails {
+                        azureSubscriptionDetails {
+                            id
+                            name
+                            accountConnectionId
+                            tenantId
+                            cloudType
+                            status
+                            regionSpecs {
+                                region
+                            }
+                        }
+                    }
+                }
             }
             count
             pageInfo {

--- a/pkg/polaris/graphql/hierarchy/queries/inventory_root.graphql
+++ b/pkg/polaris/graphql/hierarchy/queries/inventory_root.graphql
@@ -47,6 +47,21 @@ query RubrikPolarisSDKRequest($after: String, $filter: [Filter!], $first: Int, $
                         }
                     }
                 }
+                ... on AzurePostgresFlexibleServer {
+                    azureResourceGroupDetails {
+                        azureSubscriptionDetails {
+                            id
+                            name
+                            accountConnectionId
+                            tenantId
+                            cloudType
+                            status
+                            regionSpecs {
+                                region
+                            }
+                        }
+                    }
+                }
             }
             count
             pageInfo {


### PR DESCRIPTION
# Description

Adds an `AzurePostgresFlexibleServer` inventory object so a flexible server can be resolved from the inventory root by name, turning a server name into its RSC object ID for SLA domain assignment.

The type mirrors `AzureSQLManagedInstanceServer`: alongside the common object fields it exposes the parent subscription details, because the inventory query has no subscription filter and flexible server names are only unique within a subscription, so callers narrow by subscription client-side.

RSC spells this `HierarchyObjectTypeEnum` value in SCREAMING_SNAKE_CASE, `AZURE_POSTGRES_FLEXIBLE_SERVER`, unlike the CamelCase `AzureSqlManagedInstanceServer` value. The test asserts the filter so that inconsistency does not get "corrected" later.

## Related Issue

No existing issue. Third of three stacked SDK PRs; based on `draper-azure-postgres-sla-object-type`.

## Motivation and Context

Needed by the `polaris_object` data source in the Terraform provider, so a Postgres flexible server can be fed into `polaris_sla_domain_assignment`.

## How Has This Been Tested?

This is the only change in the stack that touches `inventory_root.graphql`, the query shared by every inventory caller, so it was verified against live deployments rather than only the mock server:

* On a deployment holding one flexible server, the query returned it with its parent subscription details populated, and the type filter selected it correctly.
* The pre-existing SQL Managed Instance lookup continues to work through the same query.
* On a deployment with no flexible servers the query is accepted and returns an empty result, confirming the new inline fragment does not error for accounts without the feature.

Also:

* `go generate ./...` regenerated `queries.go`; `go vet` and `go test ./pkg/polaris/graphql/hierarchy/...` clean.
* `TestAzurePostgresFlexibleServer` covers the type filter and unmarshalling, including the nested subscription details.

If RSC ever does 500 on the new inline fragment for accounts without the feature, the fallback is the dedicated `azurePostgresFlexibleServers` query, the same escape hatch the GitHub organization lookup already uses.

## Types of changes

- [ ] Bug fix (non-breaking change which fixes an issue)
- [x] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)
- [ ] Other (please describe in the Description above)

## Checklist:

- [x] My code follows the code style of this project.
- [ ] My change requires a change to the documentation.
- [ ] I have updated the documentation accordingly.
- [ ] I have updated the CHANGELOG file accordingly for the version that this merge modifies.
- [x] I have added tests to cover my changes.
- [x] All new and existing tests passed.
